### PR TITLE
Enable krackan on windows

### DIFF
--- a/.github/scripts/run_playbook_tests.py
+++ b/.github/scripts/run_playbook_tests.py
@@ -31,7 +31,7 @@ Device inference:
     Tests outside any @device: block run on all devices. When --device is
     passed on the CLI, tests whose inferred device list doesn't include that
     device are skipped.
-    Valid devices: halo, stx, krackan, rx7900xt, rx9070xt.
+    Valid devices: halo, stx, krk, rx7900xt, rx9070xt.
 
 Supported test attributes:
     - id: Unique identifier for the test (required)
@@ -124,7 +124,7 @@ from pathlib import Path
 from typing import Optional
 
 
-VALID_DEVICES = {"halo", "stx", "krackan", "rx7900xt", "rx9070xt"}
+VALID_DEVICES = {"halo", "stx", "krk", "rx7900xt", "rx9070xt"}
 
 
 @dataclass

--- a/.github/workflows/test-playbooks.yml
+++ b/.github/workflows/test-playbooks.yml
@@ -137,14 +137,14 @@ jobs:
         id: run_tests_windows
         shell: powershell
         run: |
-          python .github/scripts/run_playbook_tests.py --playbook "${{ matrix.playbook }}" --platform windows
+          python .github/scripts/run_playbook_tests.py --playbook "${{ matrix.playbook }}" --platform windows --device "${{ matrix.arch }}"
 
       - name: Extract and run tests (Linux)
         if: matrix.platform == 'linux'
         id: run_tests_linux
         shell: bash
         run: |
-          python .github/scripts/run_playbook_tests.py --playbook "${{ matrix.playbook }}" --platform linux
+          python .github/scripts/run_playbook_tests.py --playbook "${{ matrix.playbook }}" --platform linux --device "${{ matrix.arch }}"
 
       - name: Upload test artifacts
         if: always()

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -106,7 +106,7 @@ Instructions for discrete Radeon GPUs
 |-----------|----------|
 | `halo` | STX Halo |
 | `stx` | STX Point |
-| `krackan` | Krackan Point |
+| `krk` | Krackan Point |
 | `rx7900xt` | Radeon RX 7900 XT |
 | `rx9070xt` | Radeon RX 9070 XT |
 

--- a/playbooks/core/pytorch-rocm-llms/README.md
+++ b/playbooks/core/pytorch-rocm-llms/README.md
@@ -89,7 +89,7 @@ The included [run_llm.py](assets/run_llm.py) script shows how to load and genera
 
 Take a look at how prompts are tokenized and sent to the model. Understanding this process lets you adapt LLMs for any text generation or summarization task. Here's a minimal example from the script:
 
-<!-- @test:id=verify-imports timeout=60 hidden=True setup=activate-venv -->
+<!-- @test:id=verify-imports timeout=120 hidden=True setup=activate-venv -->
 ```python
 import torch
 from transformers import AutoTokenizer, AutoModelForCausalLM

--- a/playbooks/core/pytorch-rocm-llms/playbook.json
+++ b/playbooks/core/pytorch-rocm-llms/playbook.json
@@ -6,7 +6,7 @@
   "platforms": ["linux", "windows"],
   "tested_platforms": {
     "linux": [],
-    "windows": ["halo"]
+    "windows": ["halo", "krk"]
   },
   "difficulty": "beginner",
   "isNew": true,

--- a/playbooks/dependencies/pytorch.md
+++ b/playbooks/dependencies/pytorch.md
@@ -9,7 +9,7 @@ pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ torch torchvision
 ```
 <!-- @test:end -->
 <!-- @device:end -->
-<!-- @device:krackan -->
+<!-- @device:krk -->
 <!-- @test:id=install-pytorch timeout=300 setup=activate-venv -->
 ```bash
 pip install --index-url https://repo.amd.com/rocm/whl/gfx1150/ torch torchvision torchaudio

--- a/playbooks/dependencies/pytorch.md
+++ b/playbooks/dependencies/pytorch.md
@@ -12,10 +12,17 @@ pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ torch torchvision
 <!-- @device:krk -->
 <!-- @test:id=install-pytorch timeout=300 setup=activate-venv -->
 ```bash
+pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ torch torchvision torchaudio
+```
+<!-- @test:end -->
+<!-- @device:end -->
+<!-- @device:stx -->
+<!-- @test:id=install-pytorch timeout=300 setup=activate-venv -->
+```bash
 pip install --index-url https://repo.amd.com/rocm/whl/gfx1150/ torch torchvision torchaudio
 ```
 <!-- @test:end -->
 <!-- @device:end -->
-<!-- @device:stx,rx7900xt,rx9070xt -->
+<!-- @device:rx7900xt,rx9070xt -->
 See [this link](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installryz/native_linux/install-ryzen.html) for details.
 <!-- @device:end -->

--- a/website/src/app/playbooks/[id]/page.tsx
+++ b/website/src/app/playbooks/[id]/page.tsx
@@ -1122,7 +1122,7 @@ function PlaybookRunSelector({
 
 const hashToDeviceId: Record<string, Device> = {
   halo: "halo",
-  krackan: "krackan",
+  krk: "krk",
 };
 
 function deviceFromHash(hash?: string): Device | null {

--- a/website/src/components/HeroSection.tsx
+++ b/website/src/components/HeroSection.tsx
@@ -12,13 +12,13 @@ const titles: Record<string, { prefix: string; highlight: string }> = {
 
 const hashToDevice: Record<string, string> = {
   halo: "stx-halo",
-  krackan: "Krackan",
+  krk: "Krackan",
   radeon: "amd-radeon",
 };
 
 export const deviceToHash: Record<string, string> = {
   "stx-halo": "halo",
-  Krackan: "krackan",
+  Krackan: "krk",
   "amd-radeon": "radeon",
 };
 

--- a/website/src/types/playbook.ts
+++ b/website/src/types/playbook.ts
@@ -47,7 +47,7 @@
  * <!-- @device:end -->
  * ```
  * 
- * Valid device IDs: halo, stx, krackan, rx7900xt, rx9070xt.
+ * Valid device IDs: halo, stx, krk, rx7900xt, rx9070xt.
  * Content outside of `@device` tags is shown on all devices.
  * 
  * ## Pre-installed Software Dropdowns
@@ -72,16 +72,16 @@
 
 export type Platform = "windows" | "linux";
 export type Architecture = "halo" | "krk";
-export type Device = "halo" | "stx" | "krackan" | "rx7900xt" | "rx9070xt";
+export type Device = "halo" | "stx" | "krk" | "rx7900xt" | "rx9070xt";
 export type Category = "core" | "supplemental" | "backup";
 export type Difficulty = "beginner" | "intermediate" | "advanced";
 
-export const DEVICE_IDS: Device[] = ["halo", "stx", "krackan", "rx7900xt", "rx9070xt"];
+export const DEVICE_IDS: Device[] = ["halo", "stx", "krk", "rx7900xt", "rx9070xt"];
 
 export const deviceNames: Record<Device, string> = {
   halo: "STX Halo",
   stx: "STX Point",
-  krackan: "Krackan Point",
+  krk: "Krackan Point",
   rx7900xt: "RX 7900 XT",
   rx9070xt: "RX 9070 XT",
 };


### PR DESCRIPTION
This PR enables krackan on Windows. That said, those tests are not passing. The policy from now is that not all tests need to pass to merge, but we do want to get the visibility into what is failing and what is not every night.