### PR TITLE
 Show "Pre-installed" badge on core playbook cards when STX Halo is selected

### DIFF
--- a/playbooks/backup/local-foundry/playbook.json
+++ b/playbooks/backup/local-foundry/playbook.json
@@ -5,7 +5,7 @@
   "time": 60,
   "platforms": ["linux", "windows"],
   "difficulty": "intermediate",
-  "isNew": true,
+  "isNew": false,
   "isFeatured": false,
   "developed": false,
   "published": true,

--- a/playbooks/backup/mcp-research-agent/playbook.json
+++ b/playbooks/backup/mcp-research-agent/playbook.json
@@ -5,7 +5,7 @@
   "time": 60,
   "platforms": ["linux", "windows"],
   "difficulty": "intermediate",
-  "isNew": true,
+  "isNew": false,
   "isFeatured": false,
   "developed": false,
   "published": true,

--- a/playbooks/backup/openhands-agent-sdk/playbook.json
+++ b/playbooks/backup/openhands-agent-sdk/playbook.json
@@ -5,7 +5,7 @@
   "time": 60,
   "platforms": ["linux", "windows"],
   "difficulty": "intermediate",
-  "isNew": true,
+  "isNew": false,
   "isFeatured": false,
   "developed": false,
   "published": true,

--- a/playbooks/core/pytorch-rocm-llms/playbook.json
+++ b/playbooks/core/pytorch-rocm-llms/playbook.json
@@ -12,7 +12,7 @@
     "windows": ["halo"]
   },
   "difficulty": "beginner",
-  "isNew": true,
+  "isNew": false,
   "isFeatured": false,
   "developed": true,
   "published": true,

--- a/playbooks/supplemental/clustering-rccl/playbook.json
+++ b/playbooks/supplemental/clustering-rccl/playbook.json
@@ -9,7 +9,7 @@
     "windows": []
   },
   "difficulty": "advanced",
-  "isNew": true,
+  "isNew": false,
   "isFeatured": false,
   "developed": false,
   "published": true,

--- a/playbooks/supplemental/cvml/playbook.json
+++ b/playbooks/supplemental/cvml/playbook.json
@@ -9,7 +9,7 @@
     "windows": []
   },
   "difficulty": "intermediate",
-  "isNew": true,
+  "isNew": false,
   "isFeatured": false,
   "developed": false,
   "published": true,

--- a/playbooks/supplemental/lemonade-getting-started/playbook.json
+++ b/playbooks/supplemental/lemonade-getting-started/playbook.json
@@ -9,7 +9,7 @@
     "windows": []
   },
   "difficulty": "intermediate",
-  "isNew": true,
+  "isNew": false,
   "isFeatured": false,
   "developed": false,
   "published": true,

--- a/playbooks/supplemental/pytorch-finetuning/playbook.json
+++ b/playbooks/supplemental/pytorch-finetuning/playbook.json
@@ -9,7 +9,7 @@
     "linux": []
   },
   "difficulty": "intermediate",
-  "isNew": true,
+  "isNew": false,
   "isFeatured": false,
   "developed": false,
   "published": true,

--- a/playbooks/supplemental/vllm-inference/playbook.json
+++ b/playbooks/supplemental/vllm-inference/playbook.json
@@ -8,7 +8,7 @@
     "linux": []
   },
   "difficulty": "beginner",
-  "isNew": true,
+  "isNew": false,
   "isFeatured": true,
   "developed": false,
   "published": true,

--- a/website/src/components/PlaybooksSection.tsx
+++ b/website/src/components/PlaybooksSection.tsx
@@ -40,6 +40,20 @@ function DifficultyBadge({ difficulty }: { difficulty?: string }) {
   );
 }
 
+function PreinstalledBadge() {
+  return (
+    <span
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-semibold rounded bg-emerald-500/15 text-emerald-400 border border-emerald-500/30"
+      title="Software for this playbook comes pre-installed on STX Halo, so you can jump straight in"
+    >
+      <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      Pre-installed
+    </span>
+  );
+}
+
 interface PlaybooksSectionProps {
   activeDevice?: string;
 }
@@ -72,6 +86,7 @@ export default function PlaybooksSection({ activeDevice }: PlaybooksSectionProps
   const regularPlaybooks = playbooks.filter((p) => !p.isFeatured);
   const displayedPlaybooks = showAll ? regularPlaybooks : regularPlaybooks.slice(0, 6);
 
+  const isHaloSelected = activeDevice === "stx-halo";
   const deviceParam = activeDevice && activeDevice !== "all" ? `?device=${deviceToHash[activeDevice] || activeDevice}` : "";
   const playbookHref = (id: string) => `/playbooks/${id}${deviceParam}`;
 
@@ -167,6 +182,9 @@ export default function PlaybooksSection({ activeDevice }: PlaybooksSectionProps
                             New
                           </span>
                         )}
+                        {isHaloSelected && featuredPlaybook.category === "core" && (
+                          <PreinstalledBadge />
+                        )}
                         <DifficultyBadge difficulty={featuredPlaybook.difficulty} />
                         <div className="flex gap-1">
                           {featuredPlaybook.platforms.map((p) => (
@@ -217,6 +235,9 @@ export default function PlaybooksSection({ activeDevice }: PlaybooksSectionProps
                         </svg>
                       </div>
                       <div className="flex items-center gap-1.5">
+                        {isHaloSelected && playbook.category === "core" && (
+                          <PreinstalledBadge />
+                        )}
                         {playbook.isNew && (
                           <span className="px-1.5 py-0.5 bg-emerald-500/20 text-emerald-400 text-[10px] font-semibold rounded border border-emerald-500/30">
                             New


### PR DESCRIPTION
## Summary

Add a "Pre-installed" badge (green checkmark) to core playbook cards, visible only when STX Halo is the selected device. This helps users identify which playbooks have software already set up on their Halo, so they can jump straight in.

It intentionally avoids exposing the internal "core"/"supplemental" terminology. Instead, the user-facing signal is simply that the software is pre-installed. When any other device (Krackan Point, Radeon GPUs, or "All") is selected, the badge is hidden since pre-installation only applies to STX Halo.
<img width="1129" height="1051" alt="image" src="https://github.com/user-attachments/assets/a69b95bf-9513-4b68-9d53-d54132c6701e" />
