### PR TITLE
Runner heartbeat and monitoring

### DIFF
--- a/.github/workflows/monitor-runners.yml
+++ b/.github/workflows/monitor-runners.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 1 * * 1"   # every Monday at 1AM UTC
   workflow_dispatch:
-  pull_request:
 
 permissions:
   actions: read  # Required to read artifacts

--- a/.github/workflows/monitor-runners.yml
+++ b/.github/workflows/monitor-runners.yml
@@ -1,0 +1,143 @@
+name: Monitor Self-Hosted Runners
+
+on:
+  schedule:
+    - cron: "0 1 * * 1"   # every Monday at 1AM UTC
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  actions: read  # Required to read artifacts
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get list of runners
+        id: runners
+        run: |
+          # Use the same runner list as the heartbeat workflow
+          runners="xsj-aimlab-halo-0,xsj-aimlab-halo-1,xsj-aimlab-halo-02,xsj-aimlab-halo-03,xsj-aimlab-stxp-01,xsj-aimlab-stxp-02,xsj-aimlab-stxp-03,xsj-aimlab-stxp-04,xsj-aimlab-krk-01,xsj-aimlab-krk-02,xsj-aimlab-krk-03,xsj-aimlab-krk-04,APEXX-T4P-03,tp401-linux-r9700-vm,tp401-linux-w7900-vm,xsj-aimlab-radeon-7900-vm01"
+          
+          echo "names=$runners" >> $GITHUB_OUTPUT
+          echo "Using static runner list: $runners"
+
+      - name: Get artifacts
+        id: artifacts
+        run: |
+          # Fetch all artifacts with pagination
+          echo '{"artifacts":[]}' > artifacts.json
+          page=1
+          while true; do
+            response=$(curl -s \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/artifacts?per_page=100&page=$page")
+            
+            # Check if request was successful and has artifacts
+            artifact_count=$(echo "$response" | jq '.artifacts | length')
+            
+            if [ "$artifact_count" -eq 0 ] || [ "$artifact_count" = "null" ]; then
+              break
+            fi
+            
+            # Merge artifacts into our main file
+            jq -s '.[0].artifacts + .[1].artifacts | {"artifacts": .}' artifacts.json <(echo "$response") > temp.json
+            mv temp.json artifacts.json
+            
+            page=$((page + 1))
+            
+            # Safety break after 10 pages (1000 artifacts)
+            if [ $page -gt 10 ]; then
+              break
+            fi
+          done
+
+      - name: Check each runner heartbeat
+        id: check
+        run: |
+          missing=""
+          now=$(date -u +%s)
+          
+          echo "Current time: $(date -u)"
+          echo "Total artifacts found: $(jq '.artifacts | length' artifacts.json)"
+          echo "Heartbeat artifacts found: $(jq '[.artifacts[] | select(.name | startswith("heartbeat-"))] | length' artifacts.json)"
+
+          for r in $(echo "${{ steps.runners.outputs.names }}" | tr ',' ' '); do
+            [ -z "$r" ] && continue
+            echo "Checking $r"
+
+            ts=$(jq -r --arg r "$r" '[.artifacts[] | select(.name=="heartbeat-"+$r)] | sort_by(.updated_at) | last | .updated_at // empty' artifacts.json)
+
+            if [ -z "$ts" ] || [ "$ts" == "null" ]; then
+              echo "No heartbeat found for $r"
+              missing="$missing $r"
+              continue
+            fi
+
+            echo "Latest heartbeat for $r: $ts"
+            hb=$(date -d "$ts" +%s)
+            diff=$((now - hb))
+            
+            echo "Age: $diff seconds ($(($diff / 3600)) hours)"
+
+            if [ $diff -gt 691200 ]; then   # 8 days (weekly + 1 day buffer)
+              echo "Heartbeat stale for $r (last seen: $ts)"
+              missing="$missing $r"
+            else
+              echo "Heartbeat OK for $r"
+            fi
+          done
+
+          echo "missing=$missing" >> $GITHUB_OUTPUT
+
+      - name: Fail if any runner missing
+        if: steps.check.outputs.missing != ''
+        run: |
+          echo "Missing or stale runners: ${{ steps.check.outputs.missing }}"
+          exit 1
+
+      - name: Send Teams alert via Power Automate
+        if: failure()
+        run: |
+          echo "Sending Teams alert via Power Automate..."
+          response=$(curl -s -w "%{http_code}" -X POST \
+            -H "Content-Type: application/json" \
+            -d '{
+              "type": "AdaptiveCard",
+              "version": "1.3",
+              "body": [
+                {
+                  "type": "TextBlock",
+                  "text": "⚠️ Self-hosted Runner Alert",
+                  "weight": "bolder",
+                  "size": "medium",
+                  "color": "attention"
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "The following runners are offline or missing heartbeats:",
+                  "wrap": true
+                },
+                {
+                  "type": "TextBlock",
+                  "text": "${{ steps.check.outputs.missing }}",
+                  "wrap": true,
+                  "fontType": "monospace"
+                }
+              ]
+            }' \
+            "${{ secrets.TEAMS_WEBHOOK_URL }}")
+
+          http_code="${response: -3}"
+          response_body="${response%???}"
+
+          echo "HTTP Status: $http_code"
+          echo "Response: $response_body"
+
+
+          if [ "$http_code" != "200" ] && [ "$http_code" != "202" ]; then
+            echo "Power Automate webhook failed with status $http_code"
+          else
+            echo "Teams alert sent successfully via Power Automate"
+          fi

--- a/.github/workflows/runner-heartbeat.yml
+++ b/.github/workflows/runner-heartbeat.yml
@@ -1,0 +1,129 @@
+name: Runner Heartbeat
+
+on:
+  schedule:
+    - cron: "0 1 * * 0"    # every Sunday at 1AM UTC
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  actions: write  # Required to upload artifacts
+  contents: read  # Required to read repository contents
+
+jobs:
+  get-runners:
+    runs-on: ubuntu-latest
+    outputs:
+      runners: ${{ steps.get-runners.outputs.runners }}
+    steps:
+      - name: Get self-hosted runners
+        id: get-runners
+        run: |
+          # Get all self-hosted runners for this repository with pagination
+          all_runners=()
+          page=1
+          per_page=100
+          
+          while true; do
+            # Safety check to prevent infinite loops
+            if [ $page -gt 10 ]; then
+              echo "Warning: Hit pagination limit (10 pages), stopping"
+              break
+            fi
+            
+            echo "Fetching page $page..."
+            response=$(curl -s --max-time 30 \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/runners?per_page=$per_page&page=$page")
+            
+            # Check if the API call was successful
+            if [ $? -ne 0 ]; then
+              echo "Error: Failed to fetch runners from GitHub API"
+              echo "runners=[]" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+            
+            # Check if API returned an error
+            if echo "$response" | jq -e '.message' > /dev/null 2>&1; then
+              echo "Error: API returned error: $(echo "$response" | jq -r '.message')"
+              echo "runners=[]" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+            
+            # Extract runners from this page (all self-hosted, regardless of status)
+            page_runners=$(echo "$response" | jq -r '.runners[]? | select(.labels[]?.name == "self-hosted") | .name')
+            
+            # Break if no runners found on this page
+            if [ -z "$page_runners" ]; then
+              break
+            fi
+            
+            # Add to our list (safely handle names with special characters)
+            while IFS= read -r runner; do
+              if [ -n "$runner" ]; then
+                # Validate runner name (alphanumeric, hyphens, underscores only)
+                if [[ "$runner" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+                  all_runners+=("$runner")
+                else
+                  echo "Warning: Skipping runner with invalid name: $runner"
+                fi
+              fi
+            done <<< "$page_runners"
+            
+            # Check if we have more pages
+            total_count=$(echo "$response" | jq -r '.total_count // 0')
+            if [ $((page * per_page)) -ge $total_count ]; then
+              break
+            fi
+            
+            ((page++))
+          done
+          
+          echo "Total runners found: ${#all_runners[@]}"
+          
+          # Convert to JSON array
+          if [ ${#all_runners[@]} -eq 0 ]; then
+            runners_json="[]"
+          elif [ ${#all_runners[@]} -gt 256 ]; then
+            echo "Warning: Found ${#all_runners[@]} runners, but GitHub Actions matrix jobs are limited to 256"
+            echo "Taking first 256 runners for this run"
+            runners_json=$(printf '%s\n' "${all_runners[@]:0:256}" | jq -R . | jq -s .)
+          else
+            runners_json=$(printf '%s\n' "${all_runners[@]}" | jq -R . | jq -s .)
+          fi
+          
+          echo "Found runners: $runners_json"
+          echo "runners=$runners_json" >> $GITHUB_OUTPUT
+
+  heartbeat:
+    needs: get-runners
+    if: needs.get-runners.outputs.runners != '[]' && needs.get-runners.outputs.runners != ''
+    strategy:
+      matrix:
+        runner: ${{ fromJson(needs.get-runners.outputs.runners) }}
+      fail-fast: false  # Continue even if one runner fails
+    runs-on: [self-hosted, "${{ matrix.runner }}"]
+    steps:
+      - name: Create heartbeat file (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          $timestamp = Get-Date -Format "yyyy-MM-ddTHH:mm:ssK"
+          $runner = "${{ runner.name }}"
+          "$timestamp" | Out-File -FilePath "heartbeat-$runner.txt" -Encoding utf8
+
+      - name: Create heartbeat file (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          timestamp=$(date -Iseconds)
+          runner="${{ runner.name }}"
+          echo "$timestamp" > "heartbeat-$runner.txt"
+
+      - name: Upload heartbeat artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: heartbeat-${{ runner.name }}
+          path: heartbeat-${{ runner.name }}.txt
+          retention-days: 14

--- a/.github/workflows/runner-heartbeat.yml
+++ b/.github/workflows/runner-heartbeat.yml
@@ -11,98 +11,29 @@ permissions:
   contents: read  # Required to read repository contents
 
 jobs:
-  get-runners:
-    runs-on: ubuntu-latest
-    outputs:
-      runners: ${{ steps.get-runners.outputs.runners }}
-    steps:
-      - name: Get self-hosted runners
-        id: get-runners
-        run: |
-          # Get all self-hosted runners for this repository with pagination
-          all_runners=()
-          page=1
-          per_page=100
-          
-          while true; do
-            # Safety check to prevent infinite loops
-            if [ $page -gt 10 ]; then
-              echo "Warning: Hit pagination limit (10 pages), stopping"
-              break
-            fi
-            
-            echo "Fetching page $page..."
-            response=$(curl -s --max-time 30 \
-              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              "https://api.github.com/repos/${{ github.repository }}/actions/runners?per_page=$per_page&page=$page")
-            
-            # Check if the API call was successful
-            if [ $? -ne 0 ]; then
-              echo "Error: Failed to fetch runners from GitHub API"
-              echo "runners=[]" >> $GITHUB_OUTPUT
-              exit 1
-            fi
-            
-            # Check if API returned an error
-            if echo "$response" | jq -e '.message' > /dev/null 2>&1; then
-              echo "Error: API returned error: $(echo "$response" | jq -r '.message')"
-              echo "runners=[]" >> $GITHUB_OUTPUT
-              exit 1
-            fi
-            
-            # Extract runners from this page (all self-hosted, regardless of status)
-            page_runners=$(echo "$response" | jq -r '.runners[]? | select(.labels[]?.name == "self-hosted") | .name')
-            
-            # Break if no runners found on this page
-            if [ -z "$page_runners" ]; then
-              break
-            fi
-            
-            # Add to our list (safely handle names with special characters)
-            while IFS= read -r runner; do
-              if [ -n "$runner" ]; then
-                # Validate runner name (alphanumeric, hyphens, underscores only)
-                if [[ "$runner" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-                  all_runners+=("$runner")
-                else
-                  echo "Warning: Skipping runner with invalid name: $runner"
-                fi
-              fi
-            done <<< "$page_runners"
-            
-            # Check if we have more pages
-            total_count=$(echo "$response" | jq -r '.total_count // 0')
-            if [ $((page * per_page)) -ge $total_count ]; then
-              break
-            fi
-            
-            ((page++))
-          done
-          
-          echo "Total runners found: ${#all_runners[@]}"
-          
-          # Convert to JSON array
-          if [ ${#all_runners[@]} -eq 0 ]; then
-            runners_json="[]"
-          elif [ ${#all_runners[@]} -gt 256 ]; then
-            echo "Warning: Found ${#all_runners[@]} runners, but GitHub Actions matrix jobs are limited to 256"
-            echo "Taking first 256 runners for this run"
-            runners_json=$(printf '%s\n' "${all_runners[@]:0:256}" | jq -R . | jq -s .)
-          else
-            runners_json=$(printf '%s\n' "${all_runners[@]}" | jq -R . | jq -s .)
-          fi
-          
-          echo "Found runners: $runners_json"
-          echo "runners=$runners_json" >> $GITHUB_OUTPUT
-
   heartbeat:
-    needs: get-runners
-    if: needs.get-runners.outputs.runners != '[]' && needs.get-runners.outputs.runners != ''
     strategy:
       matrix:
-        runner: ${{ fromJson(needs.get-runners.outputs.runners) }}
+        runner:
+          - xsj-aimlab-halo-0
+          - xsj-aimlab-halo-1
+          - xsj-aimlab-halo-2
+          - xsj-aimlab-halo-3
+          - xsj-aimlab-halo-4
+          - xsj-aimlab-stxp-01
+          - xsj-aimlab-stxp-02
+          - xsj-aimlab-stxp-03
+          - xsj-aimlab-stxp-04
+          - xsj-aimlab-krk-01
+          - xsj-aimlab-krk-02
+          - xsj-aimlab-krk-03
+          - xsj-aimlab-krk-04
+          - APEXX-T4P-03
+          - tp401-linux-r9700-vm
+          - tp401-linux-w7900-vm
+          - xsj-aimlab-radeon-7900-vm01
       fail-fast: false  # Continue even if one runner fails
+
     runs-on: [self-hosted, "${{ matrix.runner }}"]
     steps:
       - name: Create heartbeat file (Windows)

--- a/.github/workflows/runner-heartbeat.yml
+++ b/.github/workflows/runner-heartbeat.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 1 * * 0"    # every Sunday at 1AM UTC
   workflow_dispatch:
-  pull_request:
 
 permissions:
   actions: write  # Required to upload artifacts
@@ -17,9 +16,8 @@ jobs:
         runner:
           - xsj-aimlab-halo-0
           - xsj-aimlab-halo-1
-          - xsj-aimlab-halo-2
-          - xsj-aimlab-halo-3
-          - xsj-aimlab-halo-4
+          - xsj-aimlab-halo-02
+          - xsj-aimlab-halo-03
           - xsj-aimlab-stxp-01
           - xsj-aimlab-stxp-02
           - xsj-aimlab-stxp-03


### PR DESCRIPTION
This PR adds 2 workflows to the repo:

1. `runner-heartbeat.yml` - this workflow will ping each self-hosted runner in order to check that 1) they're alive still and 2) to ensure that a workflow has run on the runner within the last 14 days (this is GitHub's retention limit for self-hosted runners, after 14 days, the runner is automatically removed). At the end of the workflow, an artifact for each runner that was successful is uploaded.
2. `monitor-runners.yml` - this workflow looks for the uploaded artifacts. If any runner's artifact is missing, a Teams message is sent to notify the team that we need to check on a runner.

The list of runners needs to be manually updated whenever a new runner is added.

Future work - once IT/AMD GitHub Admin approves the token, the workflows should be updated to automatically pull the list of available self-hosted runners that should be tested. 