### PR TITLE
Add GitHub rendering notice to all playbooks

### DIFF
--- a/playbooks/backup/dify-ai-agents/README.md
+++ b/playbooks/backup/dify-ai-agents/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Build Node Based AI Agents and RAG Workflows with Dify
 
 <!-- Playbook content goes here -->

--- a/playbooks/backup/gguf-quantization-export/README.md
+++ b/playbooks/backup/gguf-quantization-export/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Quantize and Export Models to GGUF
 
 <!-- Playbook content goes here -->

--- a/playbooks/backup/jax-getting-started/README.md
+++ b/playbooks/backup/jax-getting-started/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Getting started with Jax
 
 <!-- Playbook content goes here -->

--- a/playbooks/backup/llamacpp-spec-decoding/README.md
+++ b/playbooks/backup/llamacpp-spec-decoding/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Accelerating workloads using spec-decoding and Llama.cpp
 
 <!-- Playbook content goes here -->

--- a/playbooks/backup/llamafactory-lora-finetuning/README.md
+++ b/playbooks/backup/llamafactory-lora-finetuning/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # LoRA Fine-tuning with LLaMA-Factory
 
 <!-- Playbook content goes here -->

--- a/playbooks/backup/local-foundry/README.md
+++ b/playbooks/backup/local-foundry/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Local Foundry
 
 <!-- Playbook content goes here -->

--- a/playbooks/backup/mcp-research-agent/README.md
+++ b/playbooks/backup/mcp-research-agent/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Building a Research Agent Using MCP
 
 <!-- Playbook content goes here -->

--- a/playbooks/backup/ollama-getting-started/README.md
+++ b/playbooks/backup/ollama-getting-started/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Getting Started with Ollama
 
 <!-- Playbook content goes here -->

--- a/playbooks/backup/openhands-agent-sdk/README.md
+++ b/playbooks/backup/openhands-agent-sdk/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # OpenHands Software Agent SDK
 
 <!-- Playbook content goes here -->

--- a/playbooks/backup/openhands-coding-assistant/README.md
+++ b/playbooks/backup/openhands-coding-assistant/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # How to Use Local LLMs as a Coding Assistant in OpenHands
 
 <!-- Playbook content goes here -->

--- a/playbooks/backup/tailscale-remote-access/README.md
+++ b/playbooks/backup/tailscale-remote-access/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Setting up Tailscale To Remotely Access Halo
 
 <!-- Playbook content goes here -->

--- a/playbooks/core/comfyui-image-gen/README.md
+++ b/playbooks/core/comfyui-image-gen/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 ## Overview
 
 ComfyUI is a powerful, node-based interface for Stable Diffusion and other diffusion models. Unlike traditional text-to-image interfaces with simple prompt boxes, ComfyUI exposes the entire image generation pipeline as a visual graph, giving you fine-grained control over every step from text encoding to latent space manipulation to final decoding.

--- a/playbooks/core/lmstudio-rocm-llms/README.md
+++ b/playbooks/core/lmstudio-rocm-llms/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 ## Overview
 
 LM Studio is a powerful GUI-based wrapper for [llama.cpp](https://github.com/ggml-org/llama.cpp) and also provides an [OpenAI compliant endpoint](https://lmstudio.ai/docs/developer/openai-compat) for local model serving. LM Studio provides a simple but powerful interface to easily download and deploy models. LM Studio offers both Vulkan and ROCm based backends (called runtimes) for AMD users.

--- a/playbooks/core/n8n-automation-gpt-oss/README.md
+++ b/playbooks/core/n8n-automation-gpt-oss/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 ## Overview
 
 n8n is a workflow automation platform that lets you connect apps and services using a visual node-based editor. Instead of writing code, you build workflows by dragging, connecting, and configuring nodes.

--- a/playbooks/core/pytorch-rocm-llms/README.md
+++ b/playbooks/core/pytorch-rocm-llms/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 ## Overview
 
 Want to run powerful AI language models on your own STX Halo™ ? This guide shows you how.

--- a/playbooks/core/vscode-qwen3-coder/README.md
+++ b/playbooks/core/vscode-qwen3-coder/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Local LLM coding with VSCode and Qwen3-Coder-30B
 
 ## Overview

--- a/playbooks/supplemental/clustering-rccl/README.md
+++ b/playbooks/supplemental/clustering-rccl/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Clustering with Two Halos (RCCL)
 
 <!-- Playbook content goes here -->

--- a/playbooks/supplemental/clustering-rpc-server/README.md
+++ b/playbooks/supplemental/clustering-rpc-server/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Clustering Two STX Halos with llama.cpp RPC
 
 ## Overview

--- a/playbooks/supplemental/cvml/README.md
+++ b/playbooks/supplemental/cvml/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Local Computer Vision with Ryzen AI NPU
 
 ## Overview

--- a/playbooks/supplemental/gaia-agents/README.md
+++ b/playbooks/supplemental/gaia-agents/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Getting Started Creating Agents with GAIA
 
 <!-- Playbook content goes here -->

--- a/playbooks/supplemental/lemonade-getting-started/README.md
+++ b/playbooks/supplemental/lemonade-getting-started/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Run Generative AI Locally with Lemonade
 
 ## Overview

--- a/playbooks/supplemental/open-webui-chat/README.md
+++ b/playbooks/supplemental/open-webui-chat/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # How to Chat with LLMs in Open WebUI
 
 ## Overview

--- a/playbooks/supplemental/pytorch-finetuning/README.md
+++ b/playbooks/supplemental/pytorch-finetuning/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Fine-tune LLMs with Pytorch and ROCm
 
 ## Overview

--- a/playbooks/supplemental/pytorch-kernels/README.md
+++ b/playbooks/supplemental/pytorch-kernels/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Compile your own GPU kernels for Pytorch+ROCm
 
 <!-- Playbook content goes here -->

--- a/playbooks/supplemental/speech2speech-translation/README.md
+++ b/playbooks/supplemental/speech2speech-translation/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Live Speech2Speech Translation on AMD GPU
 
 <!-- Playbook content goes here -->

--- a/playbooks/supplemental/unsloth-qlora-finetuning/README.md
+++ b/playbooks/supplemental/unsloth-qlora-finetuning/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 # Unsloth QLoRA Fine-tuning LLMs on AMD GPUs
 
 <!-- Playbook content goes here -->

--- a/playbooks/supplemental/vllm-inference/README.md
+++ b/playbooks/supplemental/vllm-inference/README.md
@@ -1,3 +1,8 @@
+<!-- @github-only -->
+> [!IMPORTANT]
+> This playbook uses special tags that GitHub cannot render. Please visit [amd.com/playbooks](https://amd.com/playbooks) to correctly preview this content.
+<!-- @github-only:end -->
+
 
 > **🚧 Work in Progress:** This playbook is still under active development. A follow-up PR will migrate from Docker to vLLM wheels.
 

--- a/website/src/app/api/playbooks/[id]/route.ts
+++ b/website/src/app/api/playbooks/[id]/route.ts
@@ -223,6 +223,18 @@ function parseTestAttributes(attrString: string): Record<string, unknown> {
 }
 
 /**
+ * Strips <!-- @github-only --> ... <!-- @github-only:end --> blocks.
+ * These blocks contain notices intended only for GitHub readers and
+ * should never appear on the website.
+ */
+function stripGitHubOnlyBlocks(content: string): string {
+  return content.replace(
+    /<!-- @github-only -->[\s\S]*?<!-- @github-only:end -->\n?/g,
+    ''
+  );
+}
+
+/**
  * Strips lines ending with `#hide` from a fenced code block.
  * These lines are executed by the test runner but invisible to website readers.
  * Preserves the code fence delimiters (``` lines).
@@ -413,6 +425,7 @@ function findPlaybook(
           let testCoverage: TestCoverageInfo | undefined;
           if (fs.existsSync(readmePath)) {
             content = fs.readFileSync(readmePath, "utf-8");
+            content = stripGitHubOnlyBlocks(content);
             const testResult = processTestTags(content, showCoverage, resultsMap, resultsSummary, deviceResultsList, deviceSummaries);
             content = testResult.content;
             testCoverage = testResult.testCoverage;


### PR DESCRIPTION
# Description

Playbook READMEs use custom tags (`<!-- @os:... -->`, `<!-- @device:... -->`, etc.) that render correctly on our website but appear as raw HTML comments on GitHub, making the content confusing. This adds a visible > [!IMPORTANT] notice at the top of all 27 playbook READMEs directing GitHub visitors to amd.com/playbooks for the full experience.

The notice is wrapped in <!-- @github-only --> tags and automatically stripped by the API route so it never appears on the website.