### PR TITLE
Update runner label for testing from 04 to 05 for the new machine

### DIFF
--- a/.github/workflows/monitor-runners.yml
+++ b/.github/workflows/monitor-runners.yml
@@ -17,7 +17,7 @@ jobs:
         id: runners
         run: |
           # Use the same runner list as the heartbeat workflow
-          runners="xsj-aimlab-halo-0,xsj-aimlab-halo-1,xsj-aimlab-halo-02,xsj-aimlab-halo-03,xsj-aimlab-stxp-01,xsj-aimlab-stxp-02,xsj-aimlab-stxp-03,xsj-aimlab-stxp-04,xsj-aimlab-krk-01,xsj-aimlab-krk-02,xsj-aimlab-krk-03,xsj-aimlab-krk-04,APEXX-T4P-03,tp401-linux-r9700-vm,tp401-linux-w7900-vm,xsj-aimlab-radeon-7900-vm01"
+          runners="xsj-aimlab-halo-0,xsj-aimlab-halo-1,xsj-aimlab-halo-02,xsj-aimlab-halo-03,xsj-aimlab-stxp-01,xsj-aimlab-stxp-02,xsj-aimlab-stxp-03,xsj-aimlab-stxp-05,xsj-aimlab-krk-01,xsj-aimlab-krk-02,xsj-aimlab-krk-03,xsj-aimlab-krk-04,APEXX-T4P-03,tp401-linux-r9700-vm,tp401-linux-w7900-vm,xsj-aimlab-radeon-7900-vm01"
           
           echo "names=$runners" >> $GITHUB_OUTPUT
           echo "Using static runner list: $runners"

--- a/.github/workflows/runner-heartbeat.yml
+++ b/.github/workflows/runner-heartbeat.yml
@@ -21,7 +21,7 @@ jobs:
           - xsj-aimlab-stxp-01
           - xsj-aimlab-stxp-02
           - xsj-aimlab-stxp-03
-          - xsj-aimlab-stxp-04
+          - xsj-aimlab-stxp-05
           - xsj-aimlab-krk-01
           - xsj-aimlab-krk-02
           - xsj-aimlab-krk-03


### PR DESCRIPTION
Since we lost stxp-04 due to a hardware issue and replaced it with stxp-05, this PR updates the heartbeat and monitor workflows with the new device name to check on the ci runner.