### PR TITLE
Show "Already pre-installed" only on devices where it's actually preinstalled

### DIFF
--- a/playbooks/dependencies/registry.json
+++ b/playbooks/dependencies/registry.json
@@ -7,77 +7,121 @@
       "description": "Node-based Stable Diffusion interface",
       "category": "app",
       "platforms": ["windows", "linux"],
-      "file": "comfyui.md"
+      "file": "comfyui.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     },
     "pytorch": {
       "name": "PyTorch",
       "description": "Deep learning framework",
       "category": "framework",
       "platforms": ["windows", "linux"],
-      "file": "pytorch.md"
+      "file": "pytorch.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     },
     "lmstudio": {
       "name": "LM Studio",
       "description": "Desktop app for running local LLMs",
       "category": "app",
       "platforms": ["windows", "linux"],
-      "file": "lmstudio.md"
+      "file": "lmstudio.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     },
     "vllm": {
       "name": "vLLM",
       "description": "High-throughput LLM serving engine",
       "category": "framework",
       "platforms": ["linux"],
-      "file": "vllm.md"
+      "file": "vllm.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     },
     "n8n": {
       "name": "n8n",
       "description": "Workflow automation platform",
       "category": "app",
       "platforms": ["windows", "linux"],
-      "file": "n8n.md"
+      "file": "n8n.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     },
     "vscode": {
       "name": "Visual Studio Code",
       "description": "Code editor with AI extensions",
       "category": "app",
       "platforms": ["windows", "linux"],
-      "file": "vscode.md"
+      "file": "vscode.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     },
     "lemonade": {
       "name": "Lemonade",
       "description": "Local LLM server with OpenAI-compatible API",
       "category": "framework",
       "platforms": ["windows", "linux"],
-      "file": "lemonade.md"
+      "file": "lemonade.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     },
     "gaia": {
       "name": "GAIA",
       "description": "AMD framework for building AI agents on local hardware",
       "category": "framework",
       "platforms": ["windows", "linux"],
-      "file": "gaia.md"
+      "file": "gaia.md",
+      "preinstalled": {
+        "linux": [],
+        "windows": []
+      }
     },
     "comfyui-models": {
       "name": "ComfyUI Models",
       "description": "ComfyUI models for image generation",
       "category": "model",
       "platforms": ["windows", "linux"],
-      "file": "comfyui_models.md"
+      "file": "comfyui_models.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     },
     "lmstudio-models-gpt-oss-120b": {
       "name": "GPT-OSS 120B Model",
       "description": "OpenAI GPT-OSS 120B model for LM Studio",
       "category": "model",
       "platforms": ["windows", "linux"],
-      "file": "lmstudio_models_gpt_oss_120b.md"
+      "file": "lmstudio_models_gpt_oss_120b.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     },
     "driver": {
       "name": "AMD GPU Driver",
       "description": "Latest AMD GPU driver for optimal performance",
       "category": "driver",
       "platforms": ["windows", "linux"],
-      "file": "driver.md"
+      "file": "driver.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     },
     "nodejs": {
       "name": "Node.js",
@@ -85,21 +129,33 @@
       "description": "JavaScript runtime for server-side applications",
       "category": "runtime",
       "platforms": ["windows", "linux"],
-      "file": "nodejs.md"
+      "file": "nodejs.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     },
     "memory_config": {
       "name": "AMD Memory Configuration",
       "description": "Suggested memory configurations for Strix Halo Systems",
       "category": "framework",
       "platforms": ["windows", "linux"],
-      "file": "memoryconfig.md"
+      "file": "memoryconfig.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     },
     "rocm": {
       "name": "ROCm",
       "description": "AMD software platform for GPU computing and AI workloads",
       "category": "framework",
       "platforms": ["linux"],
-      "file": "rocm.md"
+      "file": "rocm.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     }
   },
   "setup": {
@@ -107,7 +163,11 @@
       "name": "Memory Configuration",
       "description": "Configure GPU memory allocation for running large models",
       "platforms": ["windows", "linux"],
-      "file": "memoryconfig.md"
+      "file": "memoryconfig.md",
+      "preinstalled": {
+        "linux": ["halo"],
+        "windows": ["halo"]
+      }
     }
   }
 }

--- a/website/src/app/api/playbooks/[id]/route.ts
+++ b/website/src/app/api/playbooks/[id]/route.ts
@@ -17,6 +17,7 @@ interface DependencyRegistry {
     category: string;
     platforms: string[];
     file: string;
+    preinstalled?: Record<string, string[]>;
   }>;
   setup?: Record<string, {
     name: string;
@@ -153,6 +154,29 @@ function processDependencyTestTags(
  * Returns the modified content plus any test info extracted from dependencies,
  * so they can be merged into the playbook's overall test coverage.
  */
+/**
+ * Computes the intersection of preinstalled device lists across multiple dependencies.
+ * A device is only considered preinstalled if ALL deps in the group list it.
+ */
+function mergePreinstalledData(maps: Array<Record<string, string[]>>): Record<string, string[]> {
+  if (maps.length === 0) return {};
+  if (maps.length === 1) return maps[0];
+
+  const allPlatforms = new Set<string>();
+  for (const m of maps) {
+    for (const p of Object.keys(m)) allPlatforms.add(p);
+  }
+
+  const result: Record<string, string[]> = {};
+  for (const platform of allPlatforms) {
+    const lists = maps.map(m => m[platform] || []);
+    result[platform] = lists[0].filter(device =>
+      lists.every(list => list.includes(device))
+    );
+  }
+  return result;
+}
+
 function processRequireTags(
   content: string,
   showCoverage: boolean,
@@ -166,12 +190,14 @@ function processRequireTags(
   const requirePattern = /<!-- @require:([a-z0-9-,]+) -->/g;
   const allDependencyTests: TestInfo[] = [];
   let totalDependencyCodeBlocks = 0;
+  const registry = loadDependencyRegistry();
   
   const processed = content.replace(requirePattern, (_match, dependencyIds: string) => {
     const ids = dependencyIds.split(',').map((id: string) => id.trim()).filter(Boolean);
     
     const contents: string[] = [];
     const notFound: string[] = [];
+    const preinstalledMaps: Array<Record<string, string[]>> = [];
     
     for (const depId of ids) {
       const depContent = loadDependencyContent(depId);
@@ -181,6 +207,9 @@ function processRequireTags(
         contents.push(proc);
         allDependencyTests.push(...tests);
         totalDependencyCodeBlocks += codeBlockCount;
+        
+        const depMeta = registry?.dependencies[depId];
+        preinstalledMaps.push(depMeta?.preinstalled || {});
       } else {
         notFound.push(depId);
       }
@@ -194,8 +223,9 @@ function processRequireTags(
       return `<!-- Dependencies "${dependencyIds}" not found -->`;
     }
     
+    const mergedPreinstalled = mergePreinstalledData(preinstalledMaps);
     const combinedContent = contents.join('\n\n---\n\n');
-    return `<!-- @preinstalled -->\n${combinedContent}\n<!-- @preinstalled:end -->`;
+    return `<!-- @preinstalled:${JSON.stringify(mergedPreinstalled)} -->\n${combinedContent}\n<!-- @preinstalled:end -->`;
   });
 
   return {

--- a/website/src/app/playbooks/[id]/page.tsx
+++ b/website/src/app/playbooks/[id]/page.tsx
@@ -621,23 +621,36 @@ function filterContentByDevice(content: string, device: Device | null): string {
 }
 
 /**
- * Transforms @preinstalled tags into collapsible dropdown HTML
+ * Transforms @preinstalled tags into either collapsible dropdown HTML (when
+ * preinstalled on the active device) or plain setup-content blocks (when not).
  * 
  * Tags supported:
- * <!-- @preinstalled --> ... <!-- @preinstalled:end -->
+ * <!-- @preinstalled:JSON --> ... <!-- @preinstalled:end -->
  * 
- * The content inside becomes a collapsible section with a special header
- * indicating the software is pre-installed on AMD Halo Developer Platform
+ * The JSON contains per-platform arrays of device IDs where the software is
+ * preinstalled, e.g. {"linux":["halo"],"windows":["halo"]}.
  */
-function transformPreinstalledBlocks(content: string): string {
+function transformPreinstalledBlocks(content: string, platform: Platform, device: Device | null): string {
   if (!content) return "";
   
-  const preinstalledPattern = /<!-- @preinstalled -->([\s\S]*?)<!-- @preinstalled:end -->/g;
+  const preinstalledPattern = /<!-- @preinstalled:(.*?) -->([\s\S]*?)<!-- @preinstalled:end -->/g;
   
-  return content.replace(preinstalledPattern, (_match, innerContent) => {
-    // Escape any HTML in the content for the data attribute
+  return content.replace(preinstalledPattern, (_match, preinstalledJson: string, innerContent: string) => {
     const escapedContent = innerContent.trim();
-    return `<div class="halo-preinstalled-dropdown" data-content="${encodeURIComponent(escapedContent)}"></div>`;
+    let isPreinstalled = false;
+    
+    try {
+      const preinstalledData = JSON.parse(preinstalledJson);
+      const deviceList: string[] = preinstalledData[platform] || [];
+      isPreinstalled = device ? deviceList.includes(device) : false;
+    } catch {
+      // Malformed JSON — fall back to showing plain instructions
+    }
+    
+    if (isPreinstalled) {
+      return `<div class="halo-preinstalled-dropdown" data-content="${encodeURIComponent(escapedContent)}"></div>`;
+    }
+    return `<div class="halo-setup-content" data-content="${encodeURIComponent(escapedContent)}"></div>`;
   });
 }
 
@@ -1307,7 +1320,9 @@ export default function PlaybookPage({ params, searchParams }: { params: Promise
           filterContentByDevice(
             filterContentByOS(playbook.content, selectedPlatform),
             selectedDevice
-          )
+          ),
+          selectedPlatform,
+          selectedDevice
         )
       )
         // Transform relative image paths in HTML img tags to use the API route


### PR DESCRIPTION
The @require tag was showing the "Already pre-installed" dropdown on all devices, but some dependencies (like GAIA) aren't preinstalled anywhere. Now the backend embeds the preinstalled metadata from registry.json into the output, and the frontend checks the current platform + device before deciding whether to show the collapsible dropdown or just the plain install instructions.