### PR TITLE
Deduplicate test identification

### DIFF
--- a/.github/scripts/run_playbook_tests.py
+++ b/.github/scripts/run_playbook_tests.py
@@ -491,7 +491,16 @@ def extract_tests(readme_path: Path, target_platform: str, target_device: Option
 
         tests.append(test)
 
-    return tests
+    # Deduplicate tests by ID, keeping the first occurrence (README order).
+    # Duplicates arise when @require tags inline the same dependency content
+    # into multiple @os: blocks, or when device variants share an ID.
+    seen_ids: set[str] = set()
+    unique_tests: list[TestBlock] = []
+    for t in tests:
+        if t.id not in seen_ids:
+            seen_ids.add(t.id)
+            unique_tests.append(t)
+    return unique_tests
 
 
 def run_test(


### PR DESCRIPTION
After collecting all tests that pass the platform/device filters, deduplicate by test ID keeping only the first occurrence. This preserves README order (so the correct first match is kept) and removes all duplicates.