### PR TITLE
Fix website treating `halo` and `halo_box` as overlapping devices

### DIFF
--- a/playbooks/core/lmstudio-rocm-llms/README.md
+++ b/playbooks/core/lmstudio-rocm-llms/README.md
@@ -120,7 +120,7 @@ This model will now be accessible through the LM Studio Server endpoint and will
 Having just created the OpenAI Compatible endpoint, let's look at how to integrate this into a Python developer environment (such as VSCode) and use your system as a local API Provider. 
 
 1. Create a Python virtual environment:
-<!-- @device:halo_box_ -->
+<!-- @device:halo_box -->
 <!-- @os:windows -->
     On Windows, open a terminal in the directory of your choice and follow the commands to create a venv.
     ```bash

--- a/playbooks/core/pytorch-rocm-llms/README.md
+++ b/playbooks/core/pytorch-rocm-llms/README.md
@@ -23,7 +23,7 @@ This tutorial uses PyTorch powered by AMD ROCm™ software to run models that ca
 
 ### Create a Virtual Environment
 
-<!-- @device:halo_box_ -->
+<!-- @device:halo_box -->
 <!-- @os:windows -->
 On Windows, open a terminal in the directory of your choice and follow the commands to create a venv with ROCm+Pytorch already installed.
 <!-- @test:id=create-venv timeout=60 -->

--- a/playbooks/dependencies/comfyui.md
+++ b/playbooks/dependencies/comfyui.md
@@ -19,7 +19,7 @@ SPDX-License-Identifier: MIT
 <!-- @os:linux -->
 
 #### Create a Virtual Environment
-<!-- @device:halo_box_ -->
+<!-- @device:halo_box -->
 On Linux, open a terminal in the directory of your choice and run the following prompt to create a venv with ROCm+Pytorch already installed:
 
 ```bash

--- a/playbooks/supplemental/unsloth-llms-finetuning/README.md
+++ b/playbooks/supplemental/unsloth-llms-finetuning/README.md
@@ -25,7 +25,7 @@ Unsloth also supports other training approaches, including QLoRA and reinforceme
 
 ## Set up your environment
 
-<!-- @device:halo_box_ -->
+<!-- @device:halo_box -->
 Open a terminal and run the following prompt to create a venv with ROCm+Pytorch already installed:
 <!-- @test:id=create-venv timeout=120 -->
 ```bash

--- a/website/src/app/playbooks/[id]/page.tsx
+++ b/website/src/app/playbooks/[id]/page.tsx
@@ -604,8 +604,9 @@ function filterContentByOS(content: string, platform: Platform): string {
  * <!-- @device:all --> ... <!-- @device:end -->
  *
  * @param devices - Active device identifiers for the current selection.
- *   When the "reference" category is active with "halo", this includes
- *   both "halo" and "halo_box" so that halo_box-specific blocks render.
+ *   The "reference" category's "halo" entry maps to "halo_box" (the AMD
+ *   Halo Developer Platform), not the bare "halo" chip; this keeps
+ *   halo-only and halo_box-only blocks from both rendering at once.
  */
 function filterContentByDevice(content: string, devices: string[]): string {
   if (!content) return "";
@@ -1399,11 +1400,18 @@ export default function PlaybookPage({ params, searchParams }: { params: Promise
     }
   }, [coverageViewActive, selectedTestDevice]);
 
+  // The "reference" category's "halo" entry represents the AMD Halo Developer
+  // Platform (halo_box), not the Strix Halo (Ryzen AI Max) chip — the chip is
+  // selected via the "apu" category. Treat them as distinct devices so that
+  // <!-- @device:halo --> blocks only render for the chip and
+  // <!-- @device:halo_box --> blocks only render for the developer platform.
+  // Content meant for both should be tagged <!-- @device:halo,halo_box -->.
   const isReferenceHalo = selectedCategory === "reference" && selectedDevice === "halo";
   const preinstalledDevice: string | null = isReferenceHalo ? "halo_box" : selectedDevice;
 
-  const activeDevices: string[] = selectedDevice ? [selectedDevice] : [];
-  if (isReferenceHalo) activeDevices.push("halo_box");
+  const activeDevices: string[] = isReferenceHalo
+    ? ["halo_box"]
+    : selectedDevice ? [selectedDevice] : [];
 
   // Transform relative image paths to API routes, filter by OS/device, and transform preinstalled/setup blocks
   const filteredContent = playbook?.content


### PR DESCRIPTION
# Description

When the user is on `Reference Platform → halo` (which is just a UI label for the developer platform), `activeDevices` used to include both `["halo", "halo_box"]`. That caused content tagged for either device to render incorrectly.

Other issue fixed: Many playbooks had `@device:halo_box_`, which I updated to `@device:halo_box`. My understanding is that we did this to mitigate the previous issue, which has now been fixed.