### PR TITLE
Fix venv name in comfyui-image-gen @setup tag

### DIFF
--- a/playbooks/core/comfyui-image-gen/README.md
+++ b/playbooks/core/comfyui-image-gen/README.md
@@ -58,7 +58,7 @@ python3 -m venv comfyui-env
 source comfyui-env/bin/activate
 ```
 <!-- @test:end -->
-<!-- @setup:id=activate-venv command="source llm-env/bin/activate" -->
+<!-- @setup:id=activate-venv command="source comfyui-env/bin/activate" -->
 <!-- @device:end -->
 
 <!-- @require:driver,pytorch,comfyui -->


### PR DESCRIPTION
The @setup:id=activate-venv command still referenced llm-env but the venv was renamed to comfyui-env, causing CI test failures.