### PR TITLE
fix(rccl): add --pids-limit=-1 to podman run command

### DIFF
--- a/playbooks/supplemental/clustering-rccl/README.md
+++ b/playbooks/supplemental/clustering-rccl/README.md
@@ -138,7 +138,7 @@ The command below launches the container and drops you into an interactive shell
 Start the container with:
 
 ```bash
-sudo podman run -it --name vllm_cluster --replace --pull missing --network=host --device /dev/kfd --device /dev/dri -v ~/.local/share/vLLM/models:/opt/vLLM/models --env HF_HOME=/opt/vLLM/models --entrypoint="bin/bash" --shm-size=64g -e NCCL_SOCKET_IFNAME=<IFNAME> -e GLOO_SOCKET_IFNAME=<IFNAME> oci-registry.ryai.dev/ryai-vllm:latest
+sudo podman run -it --name vllm_cluster --replace --pull missing --network=host --device /dev/kfd --device /dev/dri -v ~/.local/share/vLLM/models:/opt/vLLM/models --env HF_HOME=/opt/vLLM/models --entrypoint="bin/bash" --shm-size=64g --pids-limit=-1 -e NCCL_SOCKET_IFNAME=<IFNAME> -e GLOO_SOCKET_IFNAME=<IFNAME> oci-registry.ryai.dev/ryai-vllm:latest
 ```
 
 > **Note**: Replace `<IFNAME>` with the output interface name from [1. Determine Network Interfaces](#1-determine-network-interfaces)


### PR DESCRIPTION
- Adds `--pids-limit=-1` to the `podman run` command in the RCCL clustering playbook
- Removes the default container PID cap, which can cause RCCL multi-node workloads to fail mid-inference when the process count exceeds the default limit