### PR TITLE
fix(rpc): update VS Build Tools link to VS2022 and rename rpc-server binary

### DIFF
--- a/playbooks/supplemental/clustering-rpc-server/README.md
+++ b/playbooks/supplemental/clustering-rpc-server/README.md
@@ -97,7 +97,7 @@ This playbook requires two Ryzen AI Halo units and one Ethernet switch, connecte
 Please install:
 - [Git](https://git-scm.com/downloads/win)
 - [Python](https://www.python.org/downloads/)
-- [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the **Desktop Development with C++** workload
+- [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_community.exe) with the **Desktop Development with C++** workload
 - [AMD HIP SDK](https://www.amd.com/en/developer/resources/rocm-hub/hip-sdk.html)
 <!-- @os:end -->
 
@@ -389,13 +389,13 @@ At load time, llama.cpp shards the model across both nodes. Once loaded, inferen
 On Machine 2, start the RPC server to expose its GPU resources to the controller:
 <!-- @os:linux -->
 ```bash
-./rpc-server -p 50053 -c --host 0.0.0.0
+./ggml-rpc-server -p 50053 -c --host 0.0.0.0
 ```
 <!-- @os:end -->
 
 <!-- @os:windows -->
 ```powershell
-.\rpc-server.exe -p 50053 -c --host 0.0.0.0
+.\ggml-rpc-server.exe -p 50053 -c --host 0.0.0.0
 ```
 <!-- @os:end -->
 


### PR DESCRIPTION
- Update Visual Studio Build Tools download link to point directly to VS2022 installer for compatibility
- Rename rpc-server to ggml-rpc-server to reflect upstream llama.cpp binary rename