### PR TITLE
Add OrchestrAI integration into playbooks CI

### DIFF
--- a/.github/orchestrai-config.yml
+++ b/.github/orchestrai-config.yml
@@ -1,0 +1,194 @@
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+#
+# Configuration for the OrchestrAI playbook CI (test-playbooks-orchestrai.yml).
+#
+# This is the ONE place that holds environment-specific values. Everything the
+# OrchestrAI workflow needs to know about the test fleet lives here, so the
+# workflow YAML and the .github/scripts/orchestrai_*.py helpers stay generic.
+#
+# Secrets (OrchestrAI pipeline credentials) are NOT here — they come from repo secrets
+# ORCHESTRAI_PIPELINE_USER / ORCHESTRAI_PIPELINE_TOKEN. Only non-secret coordinates live in this file.
+
+# ---------------------------------------------------------------------------
+# OrchestrAI pipeline entry point
+# ---------------------------------------------------------------------------
+# NOTE: this repo is public, so the internal OrchestrAI pipeline coordinates are NOT
+# committed here. Set them as repo variables (Settings -> Variables):
+#   ORCHESTRAI_PIPELINE_URL   e.g. https://<your-pipeline-host>
+#   ORCHESTRAI_PIPELINE_JOB   e.g. <your-pipeline-job>
+# The values below are only fallbacks for local runs; the workflow passes the
+# repo variables through and they take precedence.
+pipeline:
+  url: ""
+  job: ""
+
+# The playbook repo the pipeline clones on the test machine.
+playbook_repo: "https://github.com/amd/playbooks"
+
+# Test that the pipeline runs for every playbook group. {platform} is filled in
+# (linux|windows). This single adapter test clones the repo and runs the playbook.
+test_path_template: "L4-sys/playbooks/{platform}/sys_func-playbook_runner"
+
+# ---------------------------------------------------------------------------
+# Device -> MAAS broker tags. A playbook's `arch` (device) from playbook.json's
+# tested_platforms is translated to the broker tag(s) used to acquire hardware.
+# ---------------------------------------------------------------------------
+# Device -> MAAS broker tags. These are internal fleet tag names, so they are
+# NOT committed to this public repo — set them via the ORCHESTRAI_DEVICE_TAGS
+# repo variable as a JSON map, e.g.:
+#   {"halo":["<tag>"],"stx":["<tag>"],"rx7900xt":["<tag>"]}
+# Every device a playbook.json declares must appear in that map, or the matrix
+# builder skips it with a warning. Keep the device set in sync with the native
+# runner's VALID_DEVICES in .github/scripts/run_playbook_tests.py.
+device_to_tags: {}
+
+# Device -> gfx target. The TheRock tarball is multi-arch, so this is only used
+# for the optional per-device pip path (torch[device-<gfx>]).
+device_to_gfx:
+  halo:     "gfx1151"
+  halo_box: "gfx1151"
+  stx:      "gfx1150"
+  krk:      "gfx1103"
+  rx7900xt: "gfx110X"
+  rx9070xt: "gfx120X"
+  r9700:    "gfx120X"
+
+# Device family controls Linux kernel-driver policy. Radeon devices use AMD's
+# packaged amdgpu/DKMS driver; Ryzen APUs use Ubuntu's inbox amdgpu module.
+# Every supported SKU must be classified here. An unclassified Linux device is
+# rejected before hardware is acquired rather than silently using the wrong
+# driver policy.
+device_families:
+  halo:     "ryzen_apu"
+  halo_box: "ryzen_apu"
+  stx:      "ryzen_apu"
+  krk:      "ryzen_apu"
+  rx7900xt: "radeon"
+  rx9070xt: "radeon"
+  r9700:    "radeon"
+
+# ---------------------------------------------------------------------------
+# Scheduling policy
+# ---------------------------------------------------------------------------
+
+# Extra broker tags required by specific playbooks (e.g. large models need RAM).
+extra_tags:
+  vscode-qwen3-coder:        ["ram_128gb"]
+  lmstudio-rocm-llms:        ["ram_128gb"]
+  n8n-automation-gpt-oss:    ["ram_128gb"]
+  gaia-agents:               ["ram_128gb"]
+  pytorch-rocm-llms:         ["ram_128gb"]
+  openclaw-lemonade-server:  ["ram_128gb"]
+
+# Device-specific overrides for playbooks whose hardware requirement differs by
+# SKU. Unsloth stays on the existing 128 GB Halo systems, while STX currently
+# has no RAM constraint because the OrchestrAI fleet has no 64 GB STX system.
+device_extra_tags:
+  unsloth-llms-finetuning:
+    halo:     ["ram_128gb"]
+    halo_box: ["ram_128gb"]
+    stx:      []
+
+# Devices that actually satisfy a given extra tag. A batch requesting an extra
+# tag on a device NOT listed here is dropped (the broker could never satisfy it).
+extra_tag_devices:
+  ram_128gb: ["halo", "halo_box"]
+
+# Additional (device, platforms) entries to test for a playbook, beyond what its
+# playbook.json tested_platforms declares. Always treated as non-required.
+# Empty by default; example (commented) showing the format:
+#   ollama-getting-started:
+#     - device: rx7900xt
+#       platforms: ["linux", "windows"]
+extra_devices: {}
+
+# Extra provisioning install scripts attached to specific playbooks, on top of
+# the platform-wide provisioning.*_install_scripts below. Applied ONLY to
+# batches that contain the named playbook -- so a costly, playbook-specific setup
+# (e.g. enabling WSL, which needs a reboot) runs only on batches that include it,
+# not on every machine on the platform. NOTE: install_scripts are batch-level, so
+# any OTHER playbook co-scheduled in the same batch (e.g. same device + extra
+# tags) also runs these scripts. Keep them idempotent and side-effect-safe.
+# Each entry: {script, reboot_after, platforms?}. "platforms" is an optional
+# filter; omit it to apply on all platforms. Paths resolve in ucicd-provisioning.
+extra_install_scripts:
+  # CVML validates inference on the Ryzen AI NPU. Install the matched XRT and
+  # amdxdna package before the test phase; the driver needs a reboot to become
+  # active. RAI_NPU_XRT_URL is supplied separately as a repository variable.
+  cvml:
+    - script: "InstallationScripts/ryzenai/linux-npu-xrt.sh"
+      reboot_after: true
+      platforms: ["linux"]
+
+  # openclaw-lemonade-server bridges into WSL (wsl-lemonade-bridge-windows test).
+  # Enabling the WSL + VirtualMachinePlatform features needs a reboot BEFORE the
+  # deps/test phase; reboot_after lets provisioning reboot-and-continue (the deps
+  # phase can't reboot). The app.wsl dependency then installs the Ubuntu distro
+  # once the features are active. Windows-only.
+  openclaw-lemonade-server:
+    - script: "InstallationScripts/gfx/windows-wsl.ps1"
+      reboot_after: true
+      platforms: ["windows"]
+
+# Devices to skip entirely (e.g. temporarily offline hardware).
+skip_devices: ["krk"]
+
+# ---------------------------------------------------------------------------
+# Per-run pipeline settings
+# ---------------------------------------------------------------------------
+run_settings:
+  max_duration: 240            # minutes, whole batch
+  max_test_case_duration: 90   # minutes, single playbook
+  acquire_timeout: 30          # minutes, machine acquire
+  # Machines to acquire per hardware group. 1 = all same-HW playbooks share one
+  # machine and run sequentially (saves scarce hardware). Overridable per run via
+  # the machines_per_hw_group workflow_dispatch input.
+  default_machines_per_hw_group: 1
+
+# ---------------------------------------------------------------------------
+# Provisioning: GPU stack installed on the acquired machine before the playbook.
+# App-level tools are installed by the lib.amd.playbook-runner dependency, not here.
+# ---------------------------------------------------------------------------
+provisioning:
+  # TheRock ROCm dist tarball (Linux) — a single multi-arch tarball covering all
+  # GPU targets (no per-gfx build). Set the full URL (host + version) as a repo
+  # variable so the internal URL is not committed to this public repo:
+  #   ORCHESTRAI_THEROCK_URL
+  #     e.g. https://<host>/tarball-multi-arch/therock-dist-linux-multiarch-7.14.0rc3.tar.gz
+  therock_url: ""
+
+  # Account-gated Ryzen AI Linux NPU/XRT bundle mirrored internally. The URL is
+  # supplied by ORCHESTRAI_RYZENAI_NPU_XRT_URL and is never committed here.
+  ryzenai_npu_xrt_url: ""
+
+  linux_install_scripts:
+    - script: "InstallationScripts/gfx/linux-therock-tarball.sh"
+      reboot_after: false
+
+  # Radeon discrete GPUs require AMD's packaged amdgpu kernel driver instead of
+  # the Ubuntu inbox module used by Ryzen APUs. Selection is driven by the
+  # device_families map above. The package URL is intentionally kept out of
+  # source control and supplied by the ORCHESTRAI_LINUX_DRIVER_SOURCE repository
+  # variable so driver updates do not require a code change.
+  linux_kernel_driver:
+    source: ""
+    install_scripts:
+      - script: "InstallationScripts/common/install-kernel-headers.sh"
+        reboot_after: false
+      - script: "InstallationScripts/gfx/linux.sh"
+        reboot_after: true
+
+  windows_install_scripts:
+    - script: "InstallationScripts/gfx/windows.ps1"
+      reboot_after: true
+    - script: "InstallationScripts/gfx/windows-therock-tarball.ps1"
+      reboot_after: true
+
+  # Windows AMD GPU driver source (UNC path) copied onto the machine.
+  # The UNC path is internal — set it as a repo variable, not in this public file:
+  #   ORCHESTRAI_WINDOWS_DRIVER_SOURCE   e.g. \\<host>\<share>\...\ATI
+  windows_driver:
+    source: ""
+    copy: "direct"

--- a/.github/orchestrai-config.yml
+++ b/.github/orchestrai-config.yml
@@ -1,0 +1,211 @@
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+#
+# Configuration for the OrchestrAI playbook CI (test-playbooks-orchestrai.yml).
+#
+# This is the ONE place that holds environment-specific values. Everything the
+# OrchestrAI workflow needs to know about the test fleet lives here, so the
+# workflow YAML and the .github/scripts/orchestrai_*.py helpers stay generic.
+#
+# Secrets (OrchestrAI pipeline credentials) are NOT here — they come from repo secrets
+# ORCHESTRAI_PIPELINE_URL / ORCHESTRAI_PIPELINE_USER / ORCHESTRAI_PIPELINE_TOKEN.
+# Only non-secret coordinates live in this file.
+
+# ---------------------------------------------------------------------------
+# OrchestrAI pipeline entry point
+# ---------------------------------------------------------------------------
+# NOTE: this repo is public, so the internal OrchestrAI pipeline coordinates are NOT
+# committed here. Set the pipeline URL as a repo secret and the job name as a
+# repo variable (Settings -> Secrets and variables -> Actions):
+#   ORCHESTRAI_PIPELINE_URL   (secret)   e.g. https://<your-pipeline-host>
+#   ORCHESTRAI_PIPELINE_JOB   (variable) e.g. <your-pipeline-job>
+# The values below are only fallbacks for local runs; the workflow passes the
+# repo secret/variable through and they take precedence.
+pipeline:
+  url: ""
+  job: ""
+
+# The playbook repo the pipeline clones on the test machine.
+playbook_repo: "https://github.com/amd/playbooks"
+
+# Test that the pipeline runs for every playbook group. {platform} is filled in
+# (linux|windows). This single adapter test clones the repo and runs the playbook.
+test_path_template: "L4-sys/playbooks/{platform}/sys_func-playbook_runner"
+
+# ---------------------------------------------------------------------------
+# Device -> MAAS broker tags. A playbook's `arch` (device) from playbook.json's
+# tested_platforms is translated to the broker tag(s) used to acquire hardware.
+# ---------------------------------------------------------------------------
+# Device -> MAAS broker tags. These are internal fleet tag names, so they are
+# NOT committed to this public repo — set them via the ORCHESTRAI_DEVICE_TAGS
+# repo variable as a JSON map, e.g.:
+#   {"halo":["<tag>"],"stx":["<tag>"],"rx7900xt":["<tag>"]}
+# Every device a playbook.json declares must appear in that map, or the matrix
+# builder skips it with a warning. Keep the device set in sync with the native
+# runner's VALID_DEVICES in .github/scripts/run_playbook_tests.py.
+device_to_tags: {}
+
+# Device -> gfx target. The TheRock tarball is multi-arch, so this is only used
+# for the optional per-device pip path (torch[device-<gfx>]).
+device_to_gfx:
+  halo:     "gfx1151"
+  halo_box: "gfx1151"
+  stx:      "gfx1150"
+  krk:      "gfx1103"
+  rx7900xt: "gfx110X"
+  rx9070xt: "gfx120X"
+  r9700:    "gfx120X"
+
+# Device family controls Linux kernel-driver policy. Radeon devices use AMD's
+# packaged amdgpu/DKMS driver; Ryzen APUs use Ubuntu's inbox amdgpu module.
+# Every supported SKU must be classified here. An unclassified Linux device is
+# rejected before hardware is acquired rather than silently using the wrong
+# driver policy.
+device_families:
+  halo:     "ryzen_apu"
+  halo_box: "ryzen_apu"
+  stx:      "ryzen_apu"
+  krk:      "ryzen_apu"
+  rx7900xt: "radeon"
+  rx9070xt: "radeon"
+  r9700:    "radeon"
+
+# ---------------------------------------------------------------------------
+# Scheduling policy
+# ---------------------------------------------------------------------------
+
+# Extra broker tags required by specific playbooks (e.g. large models need RAM).
+extra_tags:
+  vscode-qwen3-coder:        ["ram_128gb"]
+  lmstudio-rocm-llms:        ["ram_128gb"]
+  n8n-automation-gpt-oss:    ["ram_128gb"]
+  gaia-agents:               ["ram_128gb"]
+  pytorch-rocm-llms:         ["ram_128gb"]
+  openclaw-lemonade-server:  ["ram_128gb"]
+
+# Device-specific overrides for playbooks whose hardware requirement differs by
+# SKU. Unsloth stays on the existing 128 GB Halo systems, while STX currently
+# has no RAM constraint because the OrchestrAI fleet has no 64 GB STX system.
+device_extra_tags:
+  unsloth-llms-finetuning:
+    halo:     ["ram_128gb"]
+    halo_box: ["ram_128gb"]
+    stx:      []
+
+# Devices that actually satisfy a given extra tag. A batch requesting an extra
+# tag on a device NOT listed here is dropped (the broker could never satisfy it).
+extra_tag_devices:
+  ram_128gb: ["halo", "halo_box"]
+
+# Additional (device, platforms) entries to test for a playbook, beyond what its
+# playbook.json tested_platforms declares. Always treated as non-required.
+# Empty by default; example (commented) showing the format:
+#   ollama-getting-started:
+#     - device: rx7900xt
+#       platforms: ["linux", "windows"]
+extra_devices: {}
+
+# Extra provisioning install scripts attached to specific playbooks, on top of
+# the platform-wide provisioning.*_install_scripts below. Applied ONLY to
+# batches that contain the named playbook -- so a costly, playbook-specific setup
+# (e.g. enabling WSL, which needs a reboot) runs only on batches that include it,
+# not on every machine on the platform. NOTE: install_scripts are batch-level, so
+# any OTHER playbook co-scheduled in the same batch (e.g. same device + extra
+# tags) also runs these scripts. Keep them idempotent and side-effect-safe.
+# Each entry: {script, reboot_after, platforms?}. "platforms" is an optional
+# filter; omit it to apply on all platforms. Paths resolve in ucicd-provisioning.
+extra_install_scripts:
+  # CVML validates inference on the Ryzen AI NPU. Install the matched XRT and
+  # amdxdna package before the test phase; the driver needs a reboot to become
+  # active. RAI_NPU_XRT_URL is supplied separately as a repository variable.
+  cvml:
+    - script: "InstallationScripts/ryzenai/linux-npu-xrt.sh"
+      reboot_after: true
+      platforms: ["linux"]
+
+  # openclaw-lemonade-server bridges into WSL (wsl-lemonade-bridge-windows test).
+  # Enabling the WSL + VirtualMachinePlatform features needs a reboot BEFORE the
+  # deps/test phase; reboot_after lets provisioning reboot-and-continue (the deps
+  # phase can't reboot). The app.wsl dependency then installs the Ubuntu distro
+  # once the features are active. Windows-only.
+  openclaw-lemonade-server:
+    - script: "InstallationScripts/gfx/windows-wsl.ps1"
+      reboot_after: true
+      platforms: ["windows"]
+
+# Devices to skip entirely (e.g. temporarily offline hardware).
+skip_devices: ["krk"]
+
+# ---------------------------------------------------------------------------
+# Per-run pipeline settings
+# ---------------------------------------------------------------------------
+run_settings:
+  max_duration: 240            # minutes, whole batch
+  max_test_case_duration: 90   # minutes, single playbook
+  acquire_timeout: 30          # minutes, machine acquire
+  # Machines to acquire per hardware group. 1 = all same-HW playbooks share one
+  # machine and run sequentially (saves scarce hardware). Overridable per run via
+  # the machines_per_hw_group workflow_dispatch input.
+  default_machines_per_hw_group: 1
+
+# ---------------------------------------------------------------------------
+# Provisioning: GPU stack installed on the acquired machine before the playbook.
+# App-level tools are installed by the lib.amd.playbook-runner dependency, not here.
+# ---------------------------------------------------------------------------
+provisioning:
+  # TheRock ROCm dist tarball (Linux) — a single multi-arch tarball covering all
+  # GPU targets (no per-gfx build). Set the full URL (host + version) as a repo
+  # variable so the internal URL is not committed to this public repo:
+  #   ORCHESTRAI_THEROCK_URL
+  #     e.g. https://<host>/tarball-multi-arch/therock-dist-linux-multiarch-7.14.0rc3.tar.gz
+  therock_url: ""
+
+  # Account-gated Ryzen AI Linux NPU/XRT bundle mirrored internally. The URL is
+  # supplied by ORCHESTRAI_RYZENAI_NPU_XRT_URL and is never committed here.
+  ryzenai_npu_xrt_url: ""
+
+  linux_install_scripts:
+    - script: "InstallationScripts/gfx/linux-therock-tarball.sh"
+      reboot_after: false
+
+  # Radeon discrete GPUs require AMD's packaged amdgpu kernel driver instead of
+  # the Ubuntu inbox module used by Ryzen APUs. Selection is driven by the
+  # device_families map above. The package URL is intentionally kept out of
+  # source control and supplied by the ORCHESTRAI_LINUX_DRIVER_SOURCE repository
+  # variable so driver updates do not require a code change.
+  # Two ways to supply the amdgpu package, both injected from repo variables:
+  #   ORCHESTRAI_LINUX_DRIVER_SOURCE        a single URL (all Radeon hosts)
+  #   ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON  a per-release map, e.g.
+  #     {"ubuntu:24.04":"https://.../ubuntu/noble/amdgpu-install_X_all.deb",
+  #      "ubuntu:26.04":"https://.../ubuntu/resolute/amdgpu-install_Y_all.deb"}
+  # The map is resolved ON each machine from /etc/os-release, so an allocation
+  # that returns different Ubuntu releases still installs the right package on
+  # each host. When both are set the map wins for releases it lists.
+  linux_kernel_driver:
+    source: ""
+    sources_json: ""
+    install_scripts:
+      - script: "InstallationScripts/common/install-kernel-headers.sh"
+        reboot_after: false
+      - script: "InstallationScripts/gfx/linux.sh"
+        reboot_after: true
+
+  # NOTE: no TheRock step here. windows-therock-tarball.ps1 requires a TheRock
+  # *Windows* tarball via THEROCK_URL, but the only TheRock variable
+  # (ORCHESTRAI_THEROCK_URL) is the Linux multiarch tarball, so the step could
+  # never be satisfied -- it failed with "THEROCK_URL is required" on every
+  # Windows batch. Nothing on Windows consumes the resulting ROCm userspace
+  # (C:\TheRock\build): Windows gets its GPU runtime from the AMD driver
+  # (windows.ps1) and PyTorch from the ROCm wheel index. Re-add this only
+  # alongside a real Windows tarball URL.
+  windows_install_scripts:
+    - script: "InstallationScripts/gfx/windows.ps1"
+      reboot_after: true
+
+  # Windows AMD GPU driver source (UNC path) copied onto the machine.
+  # The UNC path is internal — set it as a repo variable, not in this public file:
+  #   ORCHESTRAI_WINDOWS_DRIVER_SOURCE   e.g. \\<host>\<share>\...\ATI
+  windows_driver:
+    source: ""
+    copy: "direct"

--- a/.github/scripts/orchestrai_matrix.py
+++ b/.github/scripts/orchestrai_matrix.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+OrchestrAI matrix/batch builder
+===============================
+
+Turns a list of playbook IDs into:
+
+  * matrix  - one entry per (playbook, platform, device) GitHub Actions test job
+  * batches - same entries grouped by (platform/device[+extra-tags]); each batch
+              becomes ONE OrchestrAI pipeline build that runs its playbooks on
+              shared hardware.
+
+Device/platform come from each playbook's playbooks/<cat>/<id>/playbook.json
+(tested_platforms / required_platforms). All environment-specific policy
+(device -> broker tags, extra tags, extra devices, skips) is read from
+.github/orchestrai-config.yml so this script stays generic.
+
+Usage:
+    orchestrai_matrix.py --playbooks '["comfyui-image-gen", ...]' \
+        [--config .github/orchestrai-config.yml] [--print]
+
+Writes matrix=/batches=/has_entries= to $GITHUB_OUTPUT when set; --print also
+dumps a human-readable summary + JSON to stdout (handy for dry runs).
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def load_config(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def build(playbooks, cfg, devices=None, platforms=None):
+    device_to_tags = cfg["device_to_tags"]
+    device_to_gfx = cfg["device_to_gfx"]
+    extra_tags = cfg.get("extra_tags", {})
+    device_extra_tags = cfg.get("device_extra_tags", {})
+    extra_tag_devices = cfg.get("extra_tag_devices", {})
+    extra_devices = cfg.get("extra_devices", {})
+    skip_devices = set(cfg.get("skip_devices", []))
+
+    matrix = []
+
+    def tags_for(playbook, device):
+        """Return device-specific tags when configured, else playbook defaults."""
+        overrides = device_extra_tags.get(playbook, {})
+        return overrides.get(device, extra_tags.get(playbook, []))
+
+    # 1) Declared platforms from each playbook's playbook.json
+    for pb_id in playbooks:
+        for cat in ("core", "supplemental"):
+            pb_file = Path(f"playbooks/{cat}/{pb_id}/playbook.json")
+            if not pb_file.exists():
+                continue
+            meta = json.loads(pb_file.read_text())
+            tested = meta.get("tested_platforms", {})
+            if not tested:
+                break
+            required = meta.get("required_platforms", {})
+            for device, platform_list in tested.items():
+                required_platforms = set(required.get(device, []))
+                for platform in platform_list:
+                    extra = tags_for(pb_id, device)
+                    batch_id = f"{platform}/{device}" + (
+                        f"+{'_'.join(extra)}" if extra else ""
+                    )
+                    matrix.append({
+                        "playbook": pb_id,
+                        "platform": platform,
+                        "arch": device,
+                        "batch_id": batch_id,
+                        "required": platform in required_platforms,
+                    })
+            break
+
+    # 2) Extra (device, platforms) entries beyond playbook.json (always optional)
+    for pb_id in playbooks:
+        for spec in extra_devices.get(pb_id, []):
+            device = spec["device"]
+            for platform in spec["platforms"]:
+                extra = tags_for(pb_id, device)
+                entry = {
+                    "playbook": pb_id,
+                    "platform": platform,
+                    "arch": device,
+                    "batch_id": f"{platform}/{device}" + (
+                        f"+{'_'.join(extra)}" if extra else ""
+                    ),
+                    "required": False,
+                }
+                if entry not in matrix:
+                    matrix.append(entry)
+
+    # 2b) Narrow to the devices / platforms the run explicitly asked for
+    #     (workflow_dispatch device/platform inputs). None/empty = no filter.
+    if devices:
+        matrix = [e for e in matrix if e["arch"] in devices]
+    if platforms:
+        matrix = [e for e in matrix if e["platform"] in platforms]
+
+    # 3) Skip offline/unsupported devices
+    matrix = [e for e in matrix if e["arch"] not in skip_devices]
+
+    # 4) Drop batches that request an extra tag the device can't satisfy
+    #    (e.g. ram_128gb on a non-128GB device — broker could never match it).
+    def device_satisfies_extras(e):
+        for tag in tags_for(e["playbook"], e["arch"]):
+            allowed = extra_tag_devices.get(tag)
+            if allowed is not None and e["arch"] not in allowed:
+                return False
+        return True
+
+    matrix = [e for e in matrix if device_satisfies_extras(e)]
+
+    # 4b) Drop entries whose device has no broker-tag mapping. Falling back to the
+    #     raw device name as a tag (the old behavior) builds a batch the MAAS
+    #     broker can never satisfy — it would queue and time out hours later.
+    #     Skip + warn instead, so a device declared in playbook.json but not yet
+    #     wired into the fleet doesn't hang the run or block the other devices.
+    unmapped = sorted({e["arch"] for e in matrix if e["arch"] not in device_to_tags})
+    if unmapped:
+        print(f"::warning::skipping device(s) with no device_to_tags mapping in "
+              f"orchestrai-config.yml: {', '.join(unmapped)} "
+              f"(add device_to_tags + device_to_gfx entries to enable)", file=sys.stderr)
+        matrix = [e for e in matrix if e["arch"] in device_to_tags]
+
+    # 5) Group into batches by batch_id
+    batches = {}
+    for e in matrix:
+        bid = e["batch_id"]
+        if bid not in batches:
+            tags = sorted(
+                device_to_tags.get(e["arch"], [e["arch"]])
+                + tags_for(e["playbook"], e["arch"])
+            )
+            batches[bid] = {
+                "platform": e["platform"],
+                "arch": e["arch"],
+                "gfx": device_to_gfx.get(e["arch"], e["arch"]),
+                "tags": tags,
+                "playbooks": [],
+            }
+        if e["playbook"] not in batches[bid]["playbooks"]:
+            batches[bid]["playbooks"].append(e["playbook"])
+
+    return matrix, batches
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--playbooks", default=os.environ.get("PLAYBOOKS", ""),
+                    help='JSON array of playbook IDs')
+    ap.add_argument("--config", default=".github/orchestrai-config.yml")
+    ap.add_argument("--devices", default=os.environ.get("DEVICES", ""),
+                    help='comma-separated device list (empty/"all" = every device)')
+    ap.add_argument("--platforms", default=os.environ.get("PLATFORMS", ""),
+                    help='comma-separated platform list (empty/"all" = linux+windows)')
+    ap.add_argument("--print", action="store_true", dest="do_print")
+    args = ap.parse_args()
+
+    def parse_csv(s):
+        s = (s or "").strip()
+        if not s or s.lower() == "all":
+            return None
+        return {x.strip() for x in s.split(",") if x.strip()}
+
+    devices = parse_csv(args.devices)
+    platforms = parse_csv(args.platforms)
+
+    raw = (args.playbooks or "").strip()
+    playbooks = json.loads(raw) if raw and raw != "[]" else []
+
+    if not playbooks:
+        matrix, batches = [], {}
+    else:
+        cfg = load_config(args.config)
+        # Internal MAAS broker tags are not committed to this (public) repo; they
+        # come from the ORCHESTRAI_DEVICE_TAGS variable (a JSON device->tags map).
+        dt = os.environ.get("ORCHESTRAI_DEVICE_TAGS")
+        if dt:
+            try:
+                cfg["device_to_tags"] = json.loads(dt)
+            except json.JSONDecodeError:
+                print("::warning::ORCHESTRAI_DEVICE_TAGS is not valid JSON — falling back to config",
+                      file=sys.stderr)
+        matrix, batches = build(playbooks, cfg, devices=devices, platforms=platforms)
+
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as f:
+            f.write(f"matrix={json.dumps(matrix)}\n")
+            f.write(f"batches={json.dumps(batches)}\n")
+            f.write(f"has_entries={'true' if matrix else 'false'}\n")
+
+    print(f"Matrix: {len(matrix)} entries, Batches: {len(batches)}", file=sys.stderr)
+    if args.do_print:
+        for bid, b in batches.items():
+            print(f"  {bid}: {', '.join(b['playbooks'])}  tags={b['tags']}",
+                  file=sys.stderr)
+        print(json.dumps({"matrix": matrix, "batches": batches}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/orchestrai_report.py
+++ b/.github/scripts/orchestrai_report.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+OrchestrAI PR-comment report
+============================
+
+Aggregates the per-playbook test-results artifacts produced by the matrix job
+into a single Markdown body for the !orc sticky PR comment.
+
+Each artifact is a directory named `test-results-<playbook>-<platform>-<arch>`
+containing summary.json ({playbook_id, platform, passed, failed, ...}). This
+walks the download dir, reads each summary, and prints the comment body
+(prefixed with a stable marker so the workflow can upsert one sticky comment).
+
+Usage:
+    orchestrai_report.py --artifacts <dir> [--run-url URL] [--sha SHA] [--ref REF]
+
+Exit code is always 0 — it only renders; the gate job decides pass/fail.
+"""
+
+import argparse
+import glob
+import json
+import os
+
+MARKER = "<!-- orchestrai-orc-report -->"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--artifacts", required=True)
+    ap.add_argument("--run-url", default="")
+    ap.add_argument("--sha", default="")
+    ap.add_argument("--ref", default="")
+    args = ap.parse_args()
+
+    rows = []
+    for path in glob.glob(os.path.join(args.artifacts, "**", "summary.json"), recursive=True):
+        try:
+            d = json.load(open(path))
+        except Exception:
+            continue
+        pb = d.get("playbook_id", "?")
+        platform = d.get("platform", "?")
+        # arch isn't in summary.json; recover it from the artifact dir name
+        # (test-results-<pb>-<platform>-<arch>).
+        arch = "?"
+        dirname = os.path.basename(os.path.dirname(path))
+        if dirname.startswith("test-results-"):
+            parts = dirname[len("test-results-"):].rsplit("-", 2)
+            if len(parts) == 3:
+                arch = parts[2]
+        passed = int(d.get("passed", 0) or 0)
+        failed = int(d.get("failed", 0) or 0)
+        ok = failed == 0 and passed > 0
+        rows.append((pb, platform, arch, ok))
+
+    rows.sort(key=lambda r: (r[0], r[1], r[2]))
+    n_pass = sum(1 for r in rows if r[3])
+    n_fail = len(rows) - n_pass
+    overall = "✅ all passed" if rows and n_fail == 0 else (
+        "❌ failures" if rows else "⚠️ no results")
+
+    lines = [MARKER, f"### OrchestrAI results — {overall} ({n_pass} passed, {n_fail} failed)", ""]
+    if rows:
+        lines += ["| Playbook | Platform | Device | Result |", "|---|---|---|---|"]
+        for pb, platform, arch, ok in rows:
+            lines.append(f"| `{pb}` | {platform} | {arch} | {'✅ pass' if ok else '❌ fail'} |")
+    else:
+        lines.append("_No playbooks were scheduled (nothing matched, or all devices were skipped)._")
+    lines.append("")
+    foot = []
+    if args.sha:
+        foot.append(f"tested `{args.sha[:8]}`" + (f" ({args.ref})" if args.ref else ""))
+    if args.run_url:
+        foot.append(f"[workflow run]({args.run_url}) — per-playbook ReportPortal links are in each job summary")
+    if foot:
+        lines.append(" · ".join(foot))
+
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/orchestrai_trigger.py
+++ b/.github/scripts/orchestrai_trigger.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+OrchestrAI pipeline trigger
+==========================
+
+For each batch (one per platform/device[+extra-tags]) builds a pipeline plan —
+one group per playbook, sharing the batch's hardware — and POSTs it to the
+OrchestrAI pipeline job (buildWithParameters). Polls the queue item until the
+build starts and records its URL so the matrix job can wait on it.
+
+Environment-specific values (OrchestrAI pipeline URL/job, provisioning scripts, TheRock
+URLs, Linux/Windows driver sources, run settings) come from
+.github/orchestrai-config.yml. Credentials come from env
+(ORCHESTRAI_PIPELINE_USER / ORCHESTRAI_PIPELINE_TOKEN).
+
+Usage:
+    orchestrai_trigger.py [--config .github/orchestrai-config.yml] [--dry-run]
+
+Inputs (env):
+    BATCHES_JSON            batches from orchestrai_matrix.py
+    GIT_REF                 github.ref (recorded as PLAYBOOK_REF)
+    MACHINES_PER_HW_GROUP   override; falls back to config default
+    ORCHESTRAI_PIPELINE_USER, ORCHESTRAI_PIPELINE_TOKEN
+
+Outputs:
+    build_urls={...}  -> $GITHUB_OUTPUT   (batch_id -> OrchestrAI pipeline build URL)
+    --dry-run prints each plan/builds payload and POSTs nothing.
+
+Fails fast (exit 1) on a misconfigured run rather than acquiring scarce
+hardware that can't provision: missing config keys, missing creds, or a batch
+whose required provisioning value (TheRock URL or Linux/Windows driver source)
+is unset.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+import yaml
+
+# curl timeouts so a stalled OrchestrAI pipeline can never hang the job (vs the default: wait
+# forever). Values are generous; the point is a finite ceiling, not tight SLAs.
+POST_TIMEOUT = ["--connect-timeout", "15", "--max-time", "120"]
+POLL_TIMEOUT = ["--connect-timeout", "10", "--max-time", "30"]
+
+
+def load_config(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def apply_env_overrides(cfg):
+    """Internal coordinates are kept out of the committed (public) config and
+    supplied at run time via repo variables. Env values win over config."""
+    j = cfg.setdefault("pipeline", {})
+    j["url"] = os.environ.get("ORCHESTRAI_PIPELINE_URL") or j.get("url", "")
+    j["job"] = os.environ.get("ORCHESTRAI_PIPELINE_JOB") or j.get("job", "")
+    prov = cfg.setdefault("provisioning", {})
+    therock = os.environ.get("ORCHESTRAI_THEROCK_URL")
+    if therock:
+        prov["therock_url"] = therock
+    linux_driver = os.environ.get("ORCHESTRAI_LINUX_DRIVER_SOURCE")
+    if linux_driver:
+        prov.setdefault("linux_kernel_driver", {})["source"] = linux_driver
+    npu_xrt = os.environ.get("ORCHESTRAI_RYZENAI_NPU_XRT_URL")
+    if npu_xrt:
+        prov["ryzenai_npu_xrt_url"] = npu_xrt
+    driver = os.environ.get("ORCHESTRAI_WINDOWS_DRIVER_SOURCE")
+    if driver:
+        prov.setdefault("windows_driver", {})["source"] = driver
+    return cfg
+
+
+def validate_config(cfg, batches):
+    """Return a list of missing required config keys (given the batches' platforms)."""
+    errs = []
+    for k in ("test_path_template", "playbook_repo"):
+        if not cfg.get(k):
+            errs.append(k)
+    rs = cfg.get("run_settings") or {}
+    for k in ("max_duration", "max_test_case_duration", "acquire_timeout"):
+        if k not in rs:
+            errs.append(f"run_settings.{k}")
+    prov = cfg.get("provisioning") or {}
+    platforms = {b.get("platform") for b in batches.values()}
+    if "linux" in platforms and not prov.get("linux_install_scripts"):
+        errs.append("provisioning.linux_install_scripts")
+    if "windows" in platforms and not prov.get("windows_install_scripts"):
+        errs.append("provisioning.windows_install_scripts")
+    return errs
+
+
+def make_plan(batch, git_ref, cfg, machines_per_hw_group, repo, sha, rocm_index_url,
+              hf_token=""):
+    platform = batch["platform"]
+    device = batch["arch"]
+    tags = batch["tags"]
+    test = cfg["test_path_template"].format(platform=platform)
+    rs = cfg["run_settings"]
+
+    groups = []
+    for pb_id in batch["playbooks"]:
+        variables = {
+            "PLAYBOOK_REPO": repo,
+            "PLAYBOOK_SHA": sha,
+            "PLAYBOOK_REF": git_ref,
+            "PLAYBOOK_ID": pb_id,
+            "PLAYBOOK_PLATFORM": platform,
+            "PLAYBOOK_DEVICE": device,
+            "ROCM_MULTI_ARCH_INDEX_URL": rocm_index_url,
+        }
+        # Authenticate HuggingFace traffic (models/datasets primed by deps fall
+        # back to a live HF pull on a mirror miss; unauthenticated calls from the
+        # shared egress IP hit HF's per-IP rate limit). Optional: omitted when the
+        # secret is unset so runs still work (just unauthenticated).
+        if hf_token:
+            variables["HF_TOKEN"] = hf_token
+        groups.append({
+            "id": f"playbook-{pb_id}",
+            "level": "L4-sys",
+            "tests": [test],
+            "maas_tags": tags,
+            "variables": variables,
+        })
+
+    return {
+        "source": "external-playbook-batch",
+        "groups": groups,
+        "run_settings": {
+            "max_duration": rs["max_duration"],
+            "max_test_case_duration": rs["max_test_case_duration"],
+            "acquire_timeout": rs["acquire_timeout"],
+            "machines_per_hw_group": machines_per_hw_group,
+        },
+    }
+
+
+def make_builds(batch, cfg):
+    """Return (builds, missing) — missing names required provisioning vars left empty."""
+    platform = batch["platform"]
+    prov = cfg.get("provisioning", {})
+    missing = []
+
+    if platform == "windows":
+        # Copy so appending per-playbook extras below doesn't mutate cfg.
+        scripts = list(prov.get("windows_install_scripts", []))
+        drv = prov.get("windows_driver", {})
+        source = drv.get("source", "")
+        if not source:
+            missing.append("ORCHESTRAI_WINDOWS_DRIVER_SOURCE")
+        build_vars = {"driver_source": source, "driver_copy": drv.get("copy", "direct")}
+    else:
+        scripts = list(prov.get("linux_install_scripts", []))
+        device = batch.get("arch", "")
+        device_family = (cfg.get("device_families") or {}).get(device)
+        if device_family not in {"radeon", "ryzen_apu"}:
+            missing.append(f"device_families.{device}")
+        kernel_driver = prov.get("linux_kernel_driver", {})
+        if device_family == "radeon":
+            source = kernel_driver.get("source", "")
+            if not source:
+                missing.append("ORCHESTRAI_LINUX_DRIVER_SOURCE")
+            # The kernel driver must be active before TheRock user-space is
+            # installed. Keep this device-specific so APUs retain the inbox
+            # amdgpu module they are validated with.
+            scripts = list(kernel_driver.get("install_scripts", [])) + scripts
+        # TheRock ships a single multi-arch tarball, so the URL is used as-is
+        # (no per-gfx templating).
+        url = prov.get("therock_url", "")
+        if not url:
+            missing.append("ORCHESTRAI_THEROCK_URL")
+        build_vars = {"THEROCK_URL": url}
+        if device_family == "radeon":
+            build_vars["driver_source"] = source
+        if "cvml" in batch.get("playbooks", []):
+            npu_xrt_url = prov.get("ryzenai_npu_xrt_url", "")
+            if not npu_xrt_url:
+                missing.append("ORCHESTRAI_RYZENAI_NPU_XRT_URL")
+            build_vars["RAI_NPU_XRT_URL"] = npu_xrt_url
+
+    # Per-playbook extra provisioning scripts (e.g. enabling WSL for
+    # openclaw-lemonade-server). Appended only to batches that actually contain
+    # the playbook, so the cost (an extra feature install + reboot) is scoped to
+    # batches with that playbook instead of every run on the platform. This is
+    # batch-level, not group-level: any other playbook co-scheduled in the same
+    # batch also gets these scripts, so they must be idempotent. Each entry may
+    # carry an optional "platforms" filter (e.g. windows-only); it is stripped
+    # before the script list is handed to the pipeline, which expects only
+    # {script, reboot_after}.
+    extra_map = cfg.get("extra_install_scripts", {})
+    seen = {s.get("script") for s in scripts}
+    for pb_id in batch.get("playbooks", []):
+        for entry in extra_map.get(pb_id, []):
+            plats = entry.get("platforms")
+            if plats and platform not in plats:
+                continue
+            script = entry.get("script")
+            if not script or script in seen:
+                continue
+            seen.add(script)
+            scripts.append({
+                "script": script,
+                "reboot_after": bool(entry.get("reboot_after", False)),
+            })
+
+    builds = {"install_scripts": scripts, "vars": build_vars}
+    return builds, missing
+
+
+def trigger(plan, builds, platform, pipeline, user, token):
+    # Use a real temp dir (not hardcoded /tmp) so this also works on non-POSIX
+    # runners; cleaned up in the finally below.
+    tmpdir = tempfile.mkdtemp(prefix="oai-")
+    plan_file = os.path.join(tmpdir, "plan.json")
+    builds_file = os.path.join(tmpdir, "builds.json")
+    headers_file = os.path.join(tmpdir, "headers.txt")
+    try:
+        with open(plan_file, "w") as f:
+            json.dump(plan, f)
+        with open(builds_file, "w") as f:
+            json.dump(builds, f)
+
+        os_image = "windows" if platform == "windows" else "ubuntu"
+        r = subprocess.run(
+            ["curl", "-sf", *POST_TIMEOUT, "-o", os.devnull, "-D", headers_file,
+             "-u", f"{user}:{token}",
+             "-X", "POST", f"{pipeline['url']}/job/{pipeline['job']}/buildWithParameters",
+             "--data-urlencode", f"PLAN_JSON@{plan_file}",
+             "--data-urlencode", f"BUILDS_JSON@{builds_file}",
+             "--data-urlencode", f"OS_IMAGE={os_image}"],
+            capture_output=True, text=True)
+        if r.returncode != 0:
+            return None
+
+        queue_url = ""
+        for line in open(headers_file).read().split("\n"):
+            if line.lower().startswith("location:"):
+                queue_url = line.split(":", 1)[1].strip()
+                break
+        if not queue_url:
+            return None
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    for _ in range(60):
+        time.sleep(10)
+        try:
+            q = subprocess.run(
+                ["curl", "-sf", *POLL_TIMEOUT, "-u", f"{user}:{token}", f"{queue_url}api/json"],
+                capture_output=True, text=True)
+            if q.returncode != 0:
+                continue
+            exe = json.loads(q.stdout).get("executable", {})
+            if exe and exe.get("url"):
+                return exe["url"]
+        except Exception:
+            pass
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default=".github/orchestrai-config.yml")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    cfg = apply_env_overrides(load_config(args.config))
+    batches = json.loads(os.environ.get("BATCHES_JSON", "{}") or "{}")
+    git_ref = os.environ.get("GIT_REF", "")
+    user = os.environ.get("ORCHESTRAI_PIPELINE_USER", "")
+    token = os.environ.get("ORCHESTRAI_PIPELINE_TOKEN", "")
+
+    cfg_errs = validate_config(cfg, batches)
+    if cfg_errs:
+        print(f"::error::orchestrai-config.yml missing required keys: {', '.join(cfg_errs)}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if not args.dry_run:
+        need = [f"pipeline.{k}" for k in ("url", "job") if not cfg["pipeline"].get(k)]
+        if not user:
+            need.append("ORCHESTRAI_PIPELINE_USER")
+        if not token:
+            need.append("ORCHESTRAI_PIPELINE_TOKEN")
+        if need:
+            print(f"::error::OrchestrAI not configured — missing: {', '.join(need)} "
+                  f"(set ORCHESTRAI_PIPELINE_URL/JOB vars and ORCHESTRAI_PIPELINE_* secrets)",
+                  file=sys.stderr)
+            sys.exit(1)
+
+    rs = cfg["run_settings"]
+    try:
+        mphg = int(os.environ.get("MACHINES_PER_HW_GROUP", "")
+                   or rs.get("default_machines_per_hw_group", 1))
+    except ValueError:
+        mphg = 1
+
+    # The pipeline clones PLAYBOOK_REPO@PLAYBOOK_SHA on the test machine. By
+    # default that's the configured repo at main; the !orc PR path overrides both
+    # so the PR's own code (including a fork head) is what actually gets tested.
+    repo = os.environ.get("ORCHESTRAI_PLAYBOOK_REPO") or cfg["playbook_repo"]
+    sha = os.environ.get("ORCHESTRAI_PLAYBOOK_SHA") or "main"
+    rocm_index_url = os.environ.get("ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL", "")
+    if not rocm_index_url:
+        print("::error::ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL repository variable is required",
+              file=sys.stderr)
+        sys.exit(1)
+
+    # Optional: HuggingFace token so live HF pulls (dep cache misses, uncached
+    # datasets) are authenticated and avoid the shared-IP rate limit. Not
+    # required -- runs still work unauthenticated, just exposed to 429s.
+    hf_token = os.environ.get("ORCHESTRAI_HF_TOKEN", "")
+    if not hf_token:
+        print("::warning::ORCHESTRAI_HF_TOKEN not set — HuggingFace traffic will be "
+              "unauthenticated and may hit the shared-IP rate limit (429)", file=sys.stderr)
+
+    # Prepare every batch first, and fail fast (before any POST) if a batch is
+    # missing required provisioning — otherwise we'd acquire a scarce machine
+    # that can't install its GPU stack and only fail much later on hardware.
+    prepared = []
+    prov_missing = {}
+    for bid, batch in batches.items():
+        builds, missing = make_builds(batch, cfg)
+        if missing:
+            prov_missing[bid] = missing
+        prepared.append((bid, batch,
+                         make_plan(batch, git_ref, cfg, mphg, repo, sha,
+                                   rocm_index_url, hf_token),
+                         builds))
+
+    if not args.dry_run and prov_missing:
+        for bid, miss in prov_missing.items():
+            print(f"::error::batch {bid}: unset provisioning {miss} — "
+                  f"set the corresponding repo variable(s)", file=sys.stderr)
+        sys.exit(1)
+
+    build_urls = {}
+    for bid, batch, plan, builds in prepared:
+        print(f"Batch {bid}: {', '.join(batch['playbooks'])}", file=sys.stderr)
+        if args.dry_run:
+            print(f"--- plan for {bid} ---")
+            print(json.dumps(plan, indent=2))
+            print(f"--- builds for {bid} ---")
+            print(json.dumps(builds, indent=2))
+            continue
+        url = trigger(plan, builds, batch["platform"], cfg["pipeline"], user, token)
+        if url:
+            print(f"  Build: {url}", file=sys.stderr)
+            build_urls[bid] = url
+        else:
+            print(f"  WARNING: trigger failed / timed out for {bid}", file=sys.stderr)
+
+    print(f"\nTriggered {len(build_urls)} OrchestrAI pipeline build(s)", file=sys.stderr)
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out and not args.dry_run:
+        with open(out, "a") as f:
+            f.write(f"build_urls={json.dumps(build_urls)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/orchestrai_trigger.py
+++ b/.github/scripts/orchestrai_trigger.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+OrchestrAI pipeline trigger
+==========================
+
+For each batch (one per platform/device[+extra-tags]) builds a pipeline plan —
+one group per playbook, sharing the batch's hardware — and POSTs it to the
+OrchestrAI pipeline job (buildWithParameters). Polls the queue item until the
+build starts and records its URL so the matrix job can wait on it.
+
+Environment-specific values (OrchestrAI pipeline URL/job, provisioning scripts, TheRock
+URLs, Linux/Windows driver sources, run settings) come from
+.github/orchestrai-config.yml. Credentials come from env
+(ORCHESTRAI_PIPELINE_USER / ORCHESTRAI_PIPELINE_TOKEN).
+
+Usage:
+    orchestrai_trigger.py [--config .github/orchestrai-config.yml] [--dry-run]
+
+Inputs (env):
+    BATCHES_JSON            batches from orchestrai_matrix.py
+    GIT_REF                 github.ref (recorded as PLAYBOOK_REF)
+    MACHINES_PER_HW_GROUP   override; falls back to config default
+    ORCHESTRAI_PIPELINE_USER, ORCHESTRAI_PIPELINE_TOKEN
+
+Outputs:
+    build_urls={...}  -> $GITHUB_OUTPUT   (batch_id -> OrchestrAI pipeline build URL)
+    --dry-run prints each plan/builds payload and POSTs nothing.
+
+Fails fast (exit 1) on a misconfigured run rather than acquiring scarce
+hardware that can't provision: missing config keys, missing creds, or a batch
+whose required provisioning value (TheRock URL or Linux/Windows driver source)
+is unset.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import yaml
+
+# Request timeouts so a stalled OrchestrAI pipeline can never hang the job (vs the
+# default: wait forever). Values are generous; the point is a finite ceiling, not
+# tight SLAs.
+POST_TIMEOUT = 120
+POLL_TIMEOUT = 30
+# The submit (buildWithParameters POST) is retried, because a submit that fails
+# before Jenkins creates a queue item leaves nothing behind and re-sending is
+# safe. A submit that DID create a queue item is never retried (see trigger()),
+# so a slow queue can never produce a duplicate build on scarce hardware.
+SUBMIT_ATTEMPTS = 3
+SUBMIT_BACKOFF = 5  # seconds, multiplied by the attempt number
+
+
+def load_config(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def apply_env_overrides(cfg):
+    """Internal coordinates are kept out of the committed (public) config and
+    supplied at run time via repo variables. Env values win over config."""
+    j = cfg.setdefault("pipeline", {})
+    j["url"] = os.environ.get("ORCHESTRAI_PIPELINE_URL") or j.get("url", "")
+    j["job"] = os.environ.get("ORCHESTRAI_PIPELINE_JOB") or j.get("job", "")
+    prov = cfg.setdefault("provisioning", {})
+    therock = os.environ.get("ORCHESTRAI_THEROCK_URL")
+    if therock:
+        prov["therock_url"] = therock
+    linux_driver = os.environ.get("ORCHESTRAI_LINUX_DRIVER_SOURCE")
+    if linux_driver:
+        prov.setdefault("linux_kernel_driver", {})["source"] = linux_driver
+    # Optional per-release map, so one batch can install the right amdgpu package
+    # whatever Ubuntu release the broker hands back:
+    #   {"ubuntu:24.04": "https://.../ubuntu/noble/amdgpu-install_X_all.deb", ...}
+    linux_driver_map = os.environ.get("ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON")
+    if linux_driver_map:
+        prov.setdefault("linux_kernel_driver", {})["sources_json"] = linux_driver_map
+    npu_xrt = os.environ.get("ORCHESTRAI_RYZENAI_NPU_XRT_URL")
+    if npu_xrt:
+        prov["ryzenai_npu_xrt_url"] = npu_xrt
+    driver = os.environ.get("ORCHESTRAI_WINDOWS_DRIVER_SOURCE")
+    if driver:
+        prov.setdefault("windows_driver", {})["source"] = driver
+    return cfg
+
+
+def validate_config(cfg, batches):
+    """Return a list of missing required config keys (given the batches' platforms)."""
+    errs = []
+    for k in ("test_path_template", "playbook_repo"):
+        if not cfg.get(k):
+            errs.append(k)
+    rs = cfg.get("run_settings") or {}
+    for k in ("max_duration", "max_test_case_duration", "acquire_timeout"):
+        if k not in rs:
+            errs.append(f"run_settings.{k}")
+    prov = cfg.get("provisioning") or {}
+    platforms = {b.get("platform") for b in batches.values()}
+    if "linux" in platforms and not prov.get("linux_install_scripts"):
+        errs.append("provisioning.linux_install_scripts")
+    if "windows" in platforms and not prov.get("windows_install_scripts"):
+        errs.append("provisioning.windows_install_scripts")
+    return errs
+
+
+def make_plan(batch, git_ref, cfg, machines_per_hw_group, repo, sha, rocm_index_url,
+              hf_token=""):
+    platform = batch["platform"]
+    device = batch["arch"]
+    tags = batch["tags"]
+    test = cfg["test_path_template"].format(platform=platform)
+    rs = cfg["run_settings"]
+
+    groups = []
+    for pb_id in batch["playbooks"]:
+        variables = {
+            "PLAYBOOK_REPO": repo,
+            "PLAYBOOK_SHA": sha,
+            "PLAYBOOK_REF": git_ref,
+            "PLAYBOOK_ID": pb_id,
+            "PLAYBOOK_PLATFORM": platform,
+            "PLAYBOOK_DEVICE": device,
+            "ROCM_MULTI_ARCH_INDEX_URL": rocm_index_url,
+        }
+        # Authenticate HuggingFace traffic (models/datasets primed by deps fall
+        # back to a live HF pull on a mirror miss; unauthenticated calls from the
+        # shared egress IP hit HF's per-IP rate limit). Optional: omitted when the
+        # secret is unset so runs still work (just unauthenticated).
+        if hf_token:
+            variables["HF_TOKEN"] = hf_token
+        groups.append({
+            "id": f"playbook-{pb_id}",
+            "level": "L4-sys",
+            "tests": [test],
+            "maas_tags": tags,
+            "variables": variables,
+        })
+
+    return {
+        "source": "external-playbook-batch",
+        "groups": groups,
+        "run_settings": {
+            "max_duration": rs["max_duration"],
+            "max_test_case_duration": rs["max_test_case_duration"],
+            "acquire_timeout": rs["acquire_timeout"],
+            "machines_per_hw_group": machines_per_hw_group,
+        },
+    }
+
+
+def make_builds(batch, cfg):
+    """Return (builds, missing) — missing names required provisioning vars left empty."""
+    platform = batch["platform"]
+    prov = cfg.get("provisioning", {})
+    missing = []
+
+    if platform == "windows":
+        # Copy so appending per-playbook extras below doesn't mutate cfg.
+        scripts = list(prov.get("windows_install_scripts", []))
+        drv = prov.get("windows_driver", {})
+        source = drv.get("source", "")
+        if not source:
+            missing.append("ORCHESTRAI_WINDOWS_DRIVER_SOURCE")
+        build_vars = {"driver_source": source, "driver_copy": drv.get("copy", "direct")}
+    else:
+        scripts = list(prov.get("linux_install_scripts", []))
+        device = batch.get("arch", "")
+        device_family = (cfg.get("device_families") or {}).get(device)
+        if device_family not in {"radeon", "ryzen_apu"}:
+            missing.append(f"device_families.{device}")
+        kernel_driver = prov.get("linux_kernel_driver", {})
+        if device_family == "radeon":
+            source = kernel_driver.get("source", "")
+            sources_json = kernel_driver.get("sources_json", "")
+            # Either form is sufficient: a single URL (the original behaviour) or
+            # a per-release map. The map wins on the host when both are present.
+            if not source and not sources_json:
+                missing.append("ORCHESTRAI_LINUX_DRIVER_SOURCE")
+            if sources_json:
+                # Validate here, before any hardware is acquired -- a malformed
+                # map would otherwise fail on the machine after the acquire wait.
+                sources_json = sources_json.strip()
+                # Pasting into the repo-variable UI sometimes leaves the whole
+                # value wrapped in quotes. Unwrap only when what is inside is
+                # itself valid JSON, so this cannot mask a genuinely broken map.
+                if (len(sources_json) >= 2 and sources_json[0] == sources_json[-1]
+                        and sources_json[0] in "\"'"):
+                    inner = sources_json[1:-1].strip()
+                    try:
+                        json.loads(inner)
+                        print("::warning::ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON was wrapped "
+                              f"in {sources_json[0]} quotes; using the value inside them",
+                              file=sys.stderr)
+                        sources_json = inner
+                    except ValueError:
+                        pass
+                # A value pasted into the variable box often carries the line
+                # breaks it was wrapped at. JSON allows whitespace between tokens
+                # but not inside a string, so a break landing in a URL is an
+                # "Invalid control character". URLs cannot contain raw newlines
+                # or tabs, so dropping them is safe -- and only attempted when
+                # the value does not already parse, so valid input is untouched.
+                try:
+                    json.loads(sources_json)
+                except ValueError:
+                    _rejoined = re.sub(r"[\n\r\t]+", "", sources_json)
+                    try:
+                        json.loads(_rejoined)
+                        print("::warning::ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON contained "
+                              "line breaks inside its values; they were removed. Set it as "
+                              "a single line to avoid this.", file=sys.stderr)
+                        sources_json = _rejoined
+                    except ValueError:
+                        pass
+                try:
+                    parsed = json.loads(sources_json)
+                except ValueError as exc:
+                    # Say what is wrong and show enough of the value to spot it;
+                    # "not valid JSON" alone leaves nothing to act on.
+                    hint = ""
+                    if any(c in sources_json for c in "\u201c\u201d\u2018\u2019"):
+                        hint = (" -- the value contains smart quotes, so it was probably "
+                                "copied from rendered text; retype it with plain \" quotes")
+                    elif "'" in sources_json and '"' not in sources_json:
+                        hint = " -- JSON requires double quotes, not single quotes"
+                    missing.append(
+                        f"ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON (not valid JSON: {exc}{hint}"
+                        f"; {len(sources_json)} chars, begins {sources_json[:24]!r})")
+                    parsed = None
+                if parsed is not None and not (
+                    isinstance(parsed, dict)
+                    and parsed
+                    and all(isinstance(k, str) and isinstance(v, str) and v
+                            for k, v in parsed.items())
+                ):
+                    missing.append(
+                        "ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON (expected a non-empty "
+                        'object of "<id>:<version_id>" -> URL)')
+                elif parsed is not None:
+                    # Finish repairing a value that was broken across lines. The
+                    # pre-parse rescue drops the newline, but the indentation that
+                    # followed it stays inside the string: the JSON then parses
+                    # while the URL is unusable, and the run fails much later on
+                    # the machine with "curl: (3) URL rejected". A URL cannot
+                    # contain whitespace, so remove it there and nowhere else.
+                    repaired = [k for k, v in parsed.items()
+                                if v.startswith(("http://", "https://")) and re.search(r"\s", v)]
+                    if repaired:
+                        for k in repaired:
+                            parsed[k] = re.sub(r"\s+", "", parsed[k])
+                        print("::warning::ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON: removed whitespace "
+                              f"from the URL(s) for {', '.join(sorted(repaired))}; set the variable "
+                              "as a single line to avoid this", file=sys.stderr)
+                        sources_json = json.dumps(parsed, separators=(",", ":"))
+            # The kernel driver must be active before TheRock user-space is
+            # installed. Keep this device-specific so APUs retain the inbox
+            # amdgpu module they are validated with.
+            scripts = list(kernel_driver.get("install_scripts", [])) + scripts
+        # TheRock ships a single multi-arch tarball, so the URL is used as-is
+        # (no per-gfx templating).
+        url = prov.get("therock_url", "")
+        if not url:
+            missing.append("ORCHESTRAI_THEROCK_URL")
+        build_vars = {"THEROCK_URL": url}
+        if device_family == "radeon":
+            # Every key here reaches the install script as an upper-cased env var
+            # (DRIVER_SOURCE / DRIVER_SOURCES_JSON), which is how gfx/linux.sh
+            # picks the package matching the release it actually booted.
+            if source:
+                build_vars["driver_source"] = source
+            if sources_json:
+                build_vars["driver_sources_json"] = sources_json
+        if "cvml" in batch.get("playbooks", []):
+            npu_xrt_url = prov.get("ryzenai_npu_xrt_url", "")
+            if not npu_xrt_url:
+                missing.append("ORCHESTRAI_RYZENAI_NPU_XRT_URL")
+            build_vars["RAI_NPU_XRT_URL"] = npu_xrt_url
+
+    # Per-playbook extra provisioning scripts (e.g. enabling WSL for
+    # openclaw-lemonade-server). Appended only to batches that actually contain
+    # the playbook, so the cost (an extra feature install + reboot) is scoped to
+    # batches with that playbook instead of every run on the platform. This is
+    # batch-level, not group-level: any other playbook co-scheduled in the same
+    # batch also gets these scripts, so they must be idempotent. Each entry may
+    # carry an optional "platforms" filter (e.g. windows-only); it is stripped
+    # before the script list is handed to the pipeline, which expects only
+    # {script, reboot_after}.
+    extra_map = cfg.get("extra_install_scripts", {})
+    seen = {s.get("script") for s in scripts}
+    for pb_id in batch.get("playbooks", []):
+        for entry in extra_map.get(pb_id, []):
+            plats = entry.get("platforms")
+            if plats and platform not in plats:
+                continue
+            script = entry.get("script")
+            if not script or script in seen:
+                continue
+            seen.add(script)
+            scripts.append({
+                "script": script,
+                "reboot_after": bool(entry.get("reboot_after", False)),
+            })
+
+    builds = {"install_scripts": scripts, "vars": build_vars}
+    return builds, missing
+
+
+def auth_header(user, token):
+    """Basic-auth header value, built in memory.
+
+    SECURITY: the credentials are deliberately NOT handed to a `curl -u
+    user:token` subprocess. argv is world-readable via /proc/<pid>/cmdline and
+    `ps` for the lifetime of the process, so on a shared/persistent self-hosted
+    runner any other local process could read the pipeline token. Doing the HTTP
+    in-process keeps the secret in this process's memory only.
+    """
+    return "Basic " + base64.b64encode(f"{user}:{token}".encode()).decode()
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Match curl's default (no -L): don't follow redirects, so the queue URL is
+    read from the original response's Location header."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def submit(plan, builds, platform, pipeline, user, token):
+    """POST the build request; return the queue-item URL, or None on failure.
+
+    A None return means no queue item was created (network error, timeout, or a
+    non-redirect HTTP error), so the caller may safely retry without risking a
+    duplicate build.
+    """
+    os_image = "windows" if platform == "windows" else "ubuntu"
+    # Same wire format as the previous `curl --data-urlencode NAME@file`: a
+    # urlencoded form body. Building it here also drops the temp files entirely.
+    body = urllib.parse.urlencode({
+        "PLAN_JSON": json.dumps(plan),
+        "BUILDS_JSON": json.dumps(builds),
+        "OS_IMAGE": os_image,
+    }).encode()
+
+    req = urllib.request.Request(
+        f"{pipeline['url']}/job/{pipeline['job']}/buildWithParameters",
+        data=body, method="POST")
+    req.add_header("Authorization", auth_header(user, token))
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+
+    try:
+        with urllib.request.build_opener(_NoRedirect).open(req, timeout=POST_TIMEOUT) as r:
+            return (r.headers.get("Location") or "").strip() or None
+    except urllib.error.HTTPError as e:
+        # Redirects surface as HTTPError because they're disabled above; a 3xx
+        # still carries the queue item in Location. Anything else is a failure
+        # (matches `curl -sf`, which fails on HTTP errors).
+        if 300 <= e.code < 400:
+            return (e.headers.get("Location") or "").strip() or None
+        return None
+    except Exception:
+        return None
+
+
+def await_build(queue_url, user, token):
+    """Poll a queue item until Jenkins assigns it an executable; return its URL."""
+    for _ in range(60):
+        time.sleep(10)
+        try:
+            q = urllib.request.Request(f"{queue_url}api/json")
+            q.add_header("Authorization", auth_header(user, token))
+            with urllib.request.urlopen(q, timeout=POLL_TIMEOUT) as resp:
+                payload = json.loads(resp.read().decode("utf-8", "replace"))
+            exe = payload.get("executable", {})
+            if exe and exe.get("url"):
+                return exe["url"]
+        except Exception:
+            pass
+    return None
+
+
+def trigger(plan, builds, platform, pipeline, user, token):
+    """Submit a build and return its URL, or None if it could not be created.
+
+    Only the submit is retried: a failed submit leaves no queue item, so
+    re-sending is safe. Once a submit succeeds we hold that one queue URL and
+    only wait on it, so a slow queue never spawns a duplicate build.
+    """
+    queue_url = None
+    for attempt in range(1, SUBMIT_ATTEMPTS + 1):
+        queue_url = submit(plan, builds, platform, pipeline, user, token)
+        if queue_url:
+            break
+        if attempt < SUBMIT_ATTEMPTS:
+            print(f"  submit attempt {attempt}/{SUBMIT_ATTEMPTS} failed; retrying",
+                  file=sys.stderr)
+            time.sleep(SUBMIT_BACKOFF * attempt)
+    if not queue_url:
+        return None
+    return await_build(queue_url, user, token)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default=".github/orchestrai-config.yml")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    cfg = apply_env_overrides(load_config(args.config))
+    batches = json.loads(os.environ.get("BATCHES_JSON", "{}") or "{}")
+    git_ref = os.environ.get("GIT_REF", "")
+    user = os.environ.get("ORCHESTRAI_PIPELINE_USER", "")
+    token = os.environ.get("ORCHESTRAI_PIPELINE_TOKEN", "")
+
+    cfg_errs = validate_config(cfg, batches)
+    if cfg_errs:
+        print(f"::error::orchestrai-config.yml missing required keys: {', '.join(cfg_errs)}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if not args.dry_run:
+        need = [f"pipeline.{k}" for k in ("url", "job") if not cfg["pipeline"].get(k)]
+        if not user:
+            need.append("ORCHESTRAI_PIPELINE_USER")
+        if not token:
+            need.append("ORCHESTRAI_PIPELINE_TOKEN")
+        if need:
+            print(f"::error::OrchestrAI not configured — missing: {', '.join(need)} "
+                  f"(set the ORCHESTRAI_PIPELINE_JOB var and the ORCHESTRAI_PIPELINE_URL/USER/TOKEN secrets)",
+                  file=sys.stderr)
+            sys.exit(1)
+
+    rs = cfg["run_settings"]
+    try:
+        mphg = int(os.environ.get("MACHINES_PER_HW_GROUP", "")
+                   or rs.get("default_machines_per_hw_group", 1))
+    except ValueError:
+        mphg = 1
+
+    # The pipeline clones PLAYBOOK_REPO@PLAYBOOK_SHA on the test machine. By
+    # default that's the configured repo at main; the !orc PR path overrides both
+    # so the PR's own code (including a fork head) is what actually gets tested.
+    repo = os.environ.get("ORCHESTRAI_PLAYBOOK_REPO") or cfg["playbook_repo"]
+    sha = os.environ.get("ORCHESTRAI_PLAYBOOK_SHA") or "main"
+    rocm_index_url = os.environ.get("ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL", "")
+    if not rocm_index_url:
+        print("::error::ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL repository variable is required",
+              file=sys.stderr)
+        sys.exit(1)
+
+    # Optional: HuggingFace token so live HF pulls (dep cache misses, uncached
+    # datasets) are authenticated and avoid the shared-IP rate limit. Not
+    # required -- runs still work unauthenticated, just exposed to 429s.
+    hf_token = os.environ.get("ORCHESTRAI_HF_TOKEN", "")
+    if not hf_token:
+        print("::warning::ORCHESTRAI_HF_TOKEN not set — HuggingFace traffic will be "
+              "unauthenticated and may hit the shared-IP rate limit (429)", file=sys.stderr)
+
+    # Prepare every batch first, and fail fast (before any POST) if a batch is
+    # missing required provisioning — otherwise we'd acquire a scarce machine
+    # that can't install its GPU stack and only fail much later on hardware.
+    prepared = []
+    prov_missing = {}
+    for bid, batch in batches.items():
+        builds, missing = make_builds(batch, cfg)
+        if missing:
+            prov_missing[bid] = missing
+        prepared.append((bid, batch,
+                         make_plan(batch, git_ref, cfg, mphg, repo, sha,
+                                   rocm_index_url, hf_token),
+                         builds))
+
+    if not args.dry_run and prov_missing:
+        for bid, miss in prov_missing.items():
+            print(f"::error::batch {bid}: unset provisioning {miss} — "
+                  f"set the corresponding repo variable(s)", file=sys.stderr)
+        sys.exit(1)
+
+    build_urls = {}
+    failed = []
+    for bid, batch, plan, builds in prepared:
+        print(f"Batch {bid}: {', '.join(batch['playbooks'])}", file=sys.stderr)
+        if args.dry_run:
+            print(f"--- plan for {bid} ---")
+            print(json.dumps(plan, indent=2))
+            print(f"--- builds for {bid} ---")
+            print(json.dumps(builds, indent=2))
+            continue
+        url = trigger(plan, builds, batch["platform"], cfg["pipeline"], user, token)
+        if url:
+            print(f"  Build: {url}", file=sys.stderr)
+            build_urls[bid] = url
+        else:
+            failed.append(bid)
+            print(f"  WARNING: trigger failed / timed out for {bid}", file=sys.stderr)
+
+    print(f"\nTriggered {len(build_urls)} OrchestrAI pipeline build(s)", file=sys.stderr)
+
+    # Emit the URLs FIRST so the batches that did trigger still run downstream,
+    # even if we exit non-zero for an empty result below.
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out and not args.dry_run:
+        with open(out, "a") as f:
+            f.write(f"build_urls={json.dumps(build_urls)}\n")
+
+    if args.dry_run:
+        return
+
+    # Surface dropped batches HERE, at the trigger, instead of letting each of
+    # their downstream test jobs discover the gap one-by-one as "No build URL".
+    if not build_urls:
+        # Nothing triggered at all: fail hard. There is no partial run to
+        # preserve, and every downstream job would otherwise fail identically.
+        print("::error::No OrchestrAI pipeline builds were triggered — every batch "
+              f"failed to submit ({len(failed)} batch(es): {', '.join(failed)}). "
+              "The pipeline was likely unreachable or rejecting builds.",
+              file=sys.stderr)
+        sys.exit(1)
+    if failed:
+        # Some batches triggered. Do NOT exit non-zero: that would skip the
+        # good batches (downstream jobs `needs` this one). A prominent error
+        # annotation names the dropped batches so the cause is visible at the
+        # trigger; their own downstream jobs still fail, so the run as a whole
+        # is not reported green.
+        print(f"::error::{len(failed)} batch(es) failed to trigger and will report "
+              f"no build URL downstream: {', '.join(failed)}. The other "
+              f"{len(build_urls)} batch(es) were triggered and will run.",
+              file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/orchestrai_verdict.py
+++ b/.github/scripts/orchestrai_verdict.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+OrchestrAI per-playbook verdict
+===============================
+
+A batch build runs several playbooks on one machine, so the OrchestrAI pipeline build's
+overall result can't tell us whether THIS playbook passed. The pipeline writes a
+per-group rollup to its summary.json:
+
+    groups["playbook-<id>"] = {passed, failed, skipped, errors, status}
+
+keyed by the submission group id (independent of completion order). This script
+resolves THIS playbook's verdict, preferring that rollup and falling back to the
+build console's per-suite lifecycle if the rollup is absent.
+
+Usage:
+    orchestrai_verdict.py     (all inputs via env)
+
+Env:
+    BUILD_URL, ORCHESTRAI_PIPELINE_USER, ORCHESTRAI_PIPELINE_TOKEN, PLAYBOOK_ID, PLATFORM
+
+Outputs:
+    test-results/summary.json   (per-playbook counts, for artifact upload)
+    rp_url=<reportportal launch url>  -> $GITHUB_OUTPUT
+    exit 0 if PASSED, 1 otherwise (including: no verdict found for this playbook)
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+COUNT_KEYS = ("passed", "failed", "skipped", "errors")
+
+
+def fetch(url, user, token):
+    r = subprocess.run(
+        ["curl", "-sf", "--connect-timeout", "10", "--max-time", "60",
+         "-u", f"{user}:{token}", url],
+        capture_output=True)
+    return r.stdout.decode("utf-8", "replace") if r.returncode == 0 else ""
+
+
+def status_from_group(grp):
+    """PASSED/FAILED from a group rollup, or None if it carries no verdict
+    (no status field and zero counts — i.e. nothing actually ran)."""
+    status = grp.get("status")
+    if status:
+        return status
+    counts = {k: grp.get(k) or 0 for k in COUNT_KEYS}
+    if sum(counts.values()) == 0:
+        return None  # ambiguous: group exists but ran nothing — don't call it PASS
+    return "FAILED" if (counts["failed"] or counts["errors"]) else "PASSED"
+
+
+def status_from_console(console, playbook):
+    """Fallback: the console exposes the per-playbook suite lifecycle even when
+    summary.json has no group for it:
+        Started suite "playbook-<id> #<n>" ... id=<sid>
+        Finished item <sid> -> PASSED|FAILED
+    """
+    esc = re.escape(playbook)
+    m = re.search(rf'Started suite "playbook-{esc} #\d+".*?id=([0-9a-fA-F-]+)', console)
+    if not m:
+        return None
+    sid = m.group(1)
+    # The separator between the item id and the status is an arrow that renders
+    # differently across console encodings (Unicode "→", ASCII "->", or mojibake
+    # if the log was decoded wrong). Match any run of non-alphanumeric characters
+    # rather than a specific arrow so the status is captured regardless.
+    fin = re.findall(rf'Finished item {re.escape(sid)}[^A-Za-z0-9]+([A-Z]+)', console)
+    return fin[-1] if fin else None
+
+
+def main():
+    user = os.environ.get("ORCHESTRAI_PIPELINE_USER", "")
+    token = os.environ.get("ORCHESTRAI_PIPELINE_TOKEN", "")
+    build_url = os.environ.get("BUILD_URL", "")
+    playbook = os.environ.get("PLAYBOOK_ID", "")
+    platform = os.environ.get("PLATFORM", "")
+
+    if not playbook or not platform:
+        print("::error::orchestrai_verdict.py: PLAYBOOK_ID and PLATFORM must be set",
+              file=sys.stderr)
+        sys.exit(1)
+
+    group_key = f"playbook-{playbook}"
+    os.makedirs("test-results", exist_ok=True)
+
+    def write_summary(ok):
+        json.dump(
+            {"playbook_id": playbook, "platform": platform, "total_tests": 1,
+             "passed": 1 if ok else 0, "failed": 0 if ok else 1,
+             "skipped": 0, "results": []},
+            open("test-results/summary.json", "w"), indent=2)
+
+    if not build_url:
+        write_summary(False)
+        print(f"::error::No OrchestrAI pipeline build URL for {playbook} ({platform})")
+        sys.exit(1)
+
+    raw = fetch(f"{build_url}artifact/.pipeline/summary.json", user, token) or "{}"
+    try:
+        summary = json.loads(raw)
+    except Exception:
+        summary = {}
+
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as f:
+            f.write(f"rp_url={summary.get('rp_launch_url', '')}\n")
+
+    # Primary: per-group rollup in summary.json.
+    status, how = None, ""
+    grp = (summary.get("groups") or {}).get(group_key)
+    if isinstance(grp, dict):
+        status = status_from_group(grp)
+        if status:
+            how = "summary.json groups"
+
+    # Fallback: scrape the build console's suite lifecycle.
+    if status is None:
+        console = fetch(f"{build_url}consoleText", user, token)
+        status = status_from_console(console, playbook)
+        if status:
+            how = "console suite lifecycle"
+
+    if status is None:
+        write_summary(False)
+        groups_present = list((summary.get("groups") or {}).keys())
+        print(f"::error::No verdict for {playbook} ({platform}): "
+              f"no groups['{group_key}'] in summary.json and no suite result in the "
+              f"console. groups present: {groups_present}")
+        sys.exit(1)
+
+    ok = (status == "PASSED")
+    write_summary(ok)
+    counts = {k: grp.get(k) for k in COUNT_KEYS} if isinstance(grp, dict) else {}
+    print(f"{playbook} ({platform}): {'PASS' if ok else 'FAIL'} "
+          f"(status={status}, via {how}, counts={counts})")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/orchestrai_verdict.py
+++ b/.github/scripts/orchestrai_verdict.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+OrchestrAI per-playbook verdict
+===============================
+
+A batch build runs several playbooks on one machine, so the OrchestrAI pipeline build's
+overall result can't tell us whether THIS playbook passed. The pipeline writes a
+per-group rollup to its summary.json:
+
+    groups["playbook-<id>"] = {passed, failed, skipped, errors, status}
+
+keyed by the submission group id (independent of completion order). This script
+resolves THIS playbook's verdict, preferring that rollup and falling back to the
+build console's per-suite lifecycle if the rollup is absent.
+
+Usage:
+    orchestrai_verdict.py     (all inputs via env)
+
+Env:
+    BUILD_URL, ORCHESTRAI_PIPELINE_USER, ORCHESTRAI_PIPELINE_TOKEN, PLAYBOOK_ID, PLATFORM
+
+Outputs:
+    test-results/summary.json   (per-playbook counts, for artifact upload)
+    rp_url=<reportportal launch url>  -> $GITHUB_OUTPUT
+    exit 0 if PASSED, 1 otherwise (including: no verdict found for this playbook)
+"""
+
+import base64
+import json
+import os
+import re
+import sys
+import urllib.request
+
+COUNT_KEYS = ("passed", "failed", "skipped", "errors")
+
+FETCH_TIMEOUT = 60
+
+
+def fetch(url, user, token):
+    """GET `url` with basic auth, returning "" on any failure.
+
+    SECURITY: the credentials are deliberately NOT handed to a `curl -u
+    user:token` subprocess. argv is world-readable via /proc/<pid>/cmdline and
+    `ps` for the lifetime of the process, so on a shared/persistent self-hosted
+    runner any other local process could read the pipeline token. Doing the HTTP
+    in-process (stdlib only — this job has no pip install step) keeps the secret
+    in this process's memory only.
+    """
+    req = urllib.request.Request(url)
+    req.add_header("Authorization",
+                   "Basic " + base64.b64encode(f"{user}:{token}".encode()).decode())
+    try:
+        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT) as r:
+            return r.read().decode("utf-8", "replace")
+    except Exception:
+        return ""
+
+
+def status_from_group(grp):
+    """PASSED/FAILED from a group rollup, or None if it carries no verdict
+    (no status field and zero counts — i.e. nothing actually ran)."""
+    status = grp.get("status")
+    if status:
+        return status
+    counts = {k: grp.get(k) or 0 for k in COUNT_KEYS}
+    if sum(counts.values()) == 0:
+        return None  # ambiguous: group exists but ran nothing — don't call it PASS
+    return "FAILED" if (counts["failed"] or counts["errors"]) else "PASSED"
+
+
+def status_from_console(console, playbook):
+    """Fallback: the console exposes the per-playbook suite lifecycle even when
+    summary.json has no group for it:
+        Started suite "playbook-<id> #<n>" ... id=<sid>
+        Finished item <sid> -> PASSED|FAILED
+    """
+    esc = re.escape(playbook)
+    m = re.search(rf'Started suite "playbook-{esc} #\d+".*?id=([0-9a-fA-F-]+)', console)
+    if not m:
+        return None
+    sid = m.group(1)
+    # The separator between the item id and the status is an arrow that renders
+    # differently across console encodings (Unicode "→", ASCII "->", or mojibake
+    # if the log was decoded wrong). Match any run of non-alphanumeric characters
+    # rather than a specific arrow so the status is captured regardless.
+    fin = re.findall(rf'Finished item {re.escape(sid)}[^A-Za-z0-9]+([A-Z]+)', console)
+    return fin[-1] if fin else None
+
+
+def main():
+    user = os.environ.get("ORCHESTRAI_PIPELINE_USER", "")
+    token = os.environ.get("ORCHESTRAI_PIPELINE_TOKEN", "")
+    build_url = os.environ.get("BUILD_URL", "")
+    playbook = os.environ.get("PLAYBOOK_ID", "")
+    platform = os.environ.get("PLATFORM", "")
+
+    if not playbook or not platform:
+        print("::error::orchestrai_verdict.py: PLAYBOOK_ID and PLATFORM must be set",
+              file=sys.stderr)
+        sys.exit(1)
+
+    group_key = f"playbook-{playbook}"
+    os.makedirs("test-results", exist_ok=True)
+
+    def write_summary(ok):
+        json.dump(
+            {"playbook_id": playbook, "platform": platform, "total_tests": 1,
+             "passed": 1 if ok else 0, "failed": 0 if ok else 1,
+             "skipped": 0, "results": []},
+            open("test-results/summary.json", "w"), indent=2)
+
+    if not build_url:
+        write_summary(False)
+        print(f"::error::No OrchestrAI pipeline build URL for {playbook} ({platform})")
+        sys.exit(1)
+
+    raw = fetch(f"{build_url}artifact/.pipeline/summary.json", user, token) or "{}"
+    try:
+        summary = json.loads(raw)
+    except Exception:
+        summary = {}
+
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as f:
+            f.write(f"rp_url={summary.get('rp_launch_url', '')}\n")
+
+    # Primary: per-group rollup in summary.json.
+    status, how = None, ""
+    grp = (summary.get("groups") or {}).get(group_key)
+    if isinstance(grp, dict):
+        status = status_from_group(grp)
+        if status:
+            how = "summary.json groups"
+
+    # Fallback: scrape the build console's suite lifecycle.
+    if status is None:
+        console = fetch(f"{build_url}consoleText", user, token)
+        status = status_from_console(console, playbook)
+        if status:
+            how = "console suite lifecycle"
+
+    if status is None:
+        write_summary(False)
+        groups_present = list((summary.get("groups") or {}).keys())
+        print(f"::error::No verdict for {playbook} ({platform}): "
+              f"no groups['{group_key}'] in summary.json and no suite result in the "
+              f"console. groups present: {groups_present}")
+        sys.exit(1)
+
+    ok = (status == "PASSED")
+    write_summary(ok)
+    counts = {k: grp.get(k) for k in COUNT_KEYS} if isinstance(grp, dict) else {}
+    print(f"{playbook} ({platform}): {'PASS' if ok else 'FAIL'} "
+          f"(status={status}, via {how}, counts={counts})")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/orchestrai-pr-command.yml
+++ b/.github/workflows/orchestrai-pr-command.yml
@@ -1,0 +1,253 @@
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+#
+# ChatOps: comment `!orc` on a PR to run that PR's playbooks via OrchestrAI and
+# get a sticky pass/fail comment back.
+#
+#   !orc            -> the playbooks changed in the PR
+#   !orc all        -> every playbook
+#   !orc a,b,c      -> the named playbooks
+#
+# Only users with write access (OWNER/MEMBER/COLLABORATOR) can trigger it, since
+# it runs internal hardware with the OrchestrAI pipeline secrets. issue_comment runs from the
+# default branch, so this file must be on the default branch to take effect.
+
+name: OrchestrAI PR command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: orchestrai-orc-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  command:
+    name: "!orc"
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '!orc') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ${{ vars.ORCHESTRAI_CONTROL_RUNNER || 'ubuntu-latest' }}
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      has_entries: ${{ steps.build-matrix.outputs.has_entries }}
+      build_urls: ${{ steps.trigger.outputs.build_urls }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      head_ref: ${{ steps.pr.outputs.head_ref }}
+    steps:
+      - name: Resolve PR + acknowledge
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API: ${{ github.api_url }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          curl -s -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+            "$API/repos/$REPO/issues/comments/$COMMENT_ID/reactions" -d '{"content":"eyes"}' >/dev/null || true
+          data=$(curl -s -H "Authorization: Bearer $GH_TOKEN" "$API/repos/$REPO/pulls/$PR")
+          py() { printf '%s' "$data" | python3 -c "import sys,json;print(json.load(sys.stdin)$1)"; }
+          # SECURITY: only same-repo PRs. issue_comment carries the repo secrets
+          # even for fork PRs, so allowing forks would let untrusted PR code run
+          # on internal hardware with the OrchestrAI pipeline token. Refuse forks outright.
+          HEAD_REPO_FULL=$(py "['head']['repo']['full_name']")
+          if [ "$HEAD_REPO_FULL" != "$REPO" ]; then
+            echo "fork=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::!orc refused: PR head '$HEAD_REPO_FULL' is a fork of '$REPO'"
+            curl -s -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "$API/repos/$REPO/issues/$PR/comments" \
+              -d '{"body":"🔒 `!orc` is only available for pull requests from branches in this repository, not forks."}' >/dev/null || true
+            exit 0
+          fi
+          {
+            echo "fork=false"
+            echo "head_sha=$(py "['head']['sha']")"
+            echo "base_sha=$(py "['base']['sha']")"
+            echo "head_ref=$(py "['head']['ref']")"
+            echo "head_repo=$(py "['head']['repo']['clone_url']")"
+          } >> "$GITHUB_OUTPUT"
+
+      - if: steps.pr.outputs.fork == 'false'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 0
+
+      - if: steps.pr.outputs.fork == 'false'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - if: steps.pr.outputs.fork == 'false'
+        run: pip install --quiet pyyaml
+
+      - name: Require OrchestrAI config
+        if: steps.pr.outputs.fork == 'false'
+        env:
+          JU: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          JT: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: |
+          if [ -z "$JU" ] || [ -z "$JT" ]; then
+            echo "::error::OrchestrAI secrets (ORCHESTRAI_PIPELINE_USER/ORCHESTRAI_PIPELINE_TOKEN) are not set"; exit 1
+          fi
+
+      - name: Parse command into playbook list
+        id: detect
+        if: steps.pr.outputs.fork == 'false'
+        env:
+          BODY: ${{ github.event.comment.body }}
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          arg=$(printf '%s' "$BODY" | head -n1 | sed -E 's/^!orc[[:space:]]*//')
+          if [ "$arg" = "all" ]; then
+            PB=$(find playbooks/core playbooks/supplemental -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sed 's|playbooks/[^/]*/||' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          elif [ -n "$arg" ]; then
+            PB=$(printf '%s' "$arg" | tr ', ' '\n\n' | sed 's/^ *//;s/ *$//' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          else
+            if ! CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- 'playbooks/core/*' 'playbooks/supplemental/*'); then
+              echo "::error::git diff failed (base $BASE_SHA not in history?)"; exit 1
+            fi
+            PB=$(echo "$CHANGED" | grep -E '^playbooks/(core|supplemental)/[^/]+/' | sed 's|playbooks/[^/]*/\([^/]*\)/.*|\1|' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          fi
+          echo "playbooks=${PB:-[]}" >> "$GITHUB_OUTPUT"
+
+      - name: Build matrix and batches
+        id: build-matrix
+        if: steps.pr.outputs.fork == 'false'
+        env:
+          PLAYBOOKS: ${{ steps.detect.outputs.playbooks }}
+          ORCHESTRAI_DEVICE_TAGS: ${{ vars.ORCHESTRAI_DEVICE_TAGS }}
+        run: python3 .github/scripts/orchestrai_matrix.py
+
+      - name: Trigger OrchestrAI pipeline builds (PR code)
+        id: trigger
+        if: steps.pr.outputs.fork == 'false' && steps.build-matrix.outputs.has_entries == 'true'
+        env:
+          BATCHES_JSON: ${{ steps.build-matrix.outputs.batches }}
+          GIT_REF: ${{ steps.pr.outputs.head_ref }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+          ORCHESTRAI_PIPELINE_URL: ${{ vars.ORCHESTRAI_PIPELINE_URL }}
+          ORCHESTRAI_PIPELINE_JOB: ${{ vars.ORCHESTRAI_PIPELINE_JOB }}
+          ORCHESTRAI_THEROCK_URL: ${{ vars.ORCHESTRAI_THEROCK_URL }}
+          ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL: ${{ vars.ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL }}
+          ORCHESTRAI_LINUX_DRIVER_SOURCE: ${{ vars.ORCHESTRAI_LINUX_DRIVER_SOURCE }}
+          ORCHESTRAI_RYZENAI_NPU_XRT_URL: ${{ vars.ORCHESTRAI_RYZENAI_NPU_XRT_URL }}
+          ORCHESTRAI_WINDOWS_DRIVER_SOURCE: ${{ vars.ORCHESTRAI_WINDOWS_DRIVER_SOURCE }}
+          # Test the PR's own code, not the configured repo@main.
+          ORCHESTRAI_PLAYBOOK_REPO: ${{ steps.pr.outputs.head_repo }}
+          ORCHESTRAI_PLAYBOOK_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: python3 .github/scripts/orchestrai_trigger.py
+
+  test-playbooks:
+    needs: command
+    if: needs.command.outputs.has_entries == 'true'
+    runs-on: ${{ vars.ORCHESTRAI_WAIT_RUNNER || 'ubuntu-latest' }}
+    continue-on-error: ${{ !matrix.required }}
+    strategy:
+      fail-fast: false
+      max-parallel: 16
+      matrix:
+        include: ${{ fromJson(needs.command.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.command.outputs.head_sha }}
+
+      - name: Wait for OrchestrAI pipeline build
+        id: wait
+        env:
+          BUILD_URLS_JSON: ${{ needs.command.outputs.build_urls }}
+          BATCH_ID: ${{ matrix.batch_id }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: |
+          BUILD_URL=$(python3 -c "import json,os;print(json.loads(os.environ.get('BUILD_URLS_JSON','{}') or '{}').get(os.environ['BATCH_ID'],''))")
+          if [ -z "$BUILD_URL" ]; then
+            echo "::error::No OrchestrAI pipeline build URL for batch ${BATCH_ID}"; exit 1
+          fi
+          echo "build_url=${BUILD_URL}" >> "$GITHUB_OUTPUT"
+          echo "Waiting for OrchestrAI pipeline build ..."
+          MAX=1080; FAIL_MAX=20; i=0; fails=0
+          while [ "$i" -lt "$MAX" ]; do
+            if data=$(curl -sf --connect-timeout 10 --max-time 30 -u "${ORCHESTRAI_PIPELINE_USER}:${ORCHESTRAI_PIPELINE_TOKEN}" "${BUILD_URL}api/json?tree=result,building" 2>/dev/null); then
+              fails=0
+              building=$(echo "$data" | python3 -c "import sys,json;print(json.load(sys.stdin).get('building',True))" 2>/dev/null || echo "True")
+              result=$(echo "$data" | python3 -c "import sys,json;print(json.load(sys.stdin).get('result') or '')" 2>/dev/null || echo "")
+              if [ "$building" = "False" ] && [ -n "$result" ]; then
+                echo "Batch build finished: $result"; break
+              fi
+            else
+              fails=$((fails + 1))
+              if [ "$fails" -ge "$FAIL_MAX" ]; then
+                echo "::error::OrchestrAI pipeline unreachable"; exit 1
+              fi
+            fi
+            i=$((i + 1)); sleep 15
+          done
+          if [ "$i" -ge "$MAX" ]; then echo "::error::Timed out waiting for OrchestrAI pipeline build"; exit 1; fi
+
+      - name: Resolve per-playbook verdict
+        if: always()
+        env:
+          BUILD_URL: ${{ steps.wait.outputs.build_url }}
+          PLAYBOOK_ID: ${{ matrix.playbook }}
+          PLATFORM: ${{ matrix.platform }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: python3 .github/scripts/orchestrai_verdict.py
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-${{ matrix.playbook }}-${{ matrix.platform }}-${{ matrix.arch }}
+          path: test-results/
+          if-no-files-found: ignore
+
+  report:
+    needs: [command, test-playbooks]
+    if: always() && needs.command.result == 'success' && needs.command.outputs.head_sha != ''
+    runs-on: ${{ vars.ORCHESTRAI_CONTROL_RUNNER || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.command.outputs.head_sha }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - uses: actions/download-artifact@v7
+        with:
+          path: artifacts
+        continue-on-error: true
+
+      - name: Build + upsert sticky comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API: ${{ github.api_url }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+          HEAD_SHA: ${{ needs.command.outputs.head_sha }}
+          HEAD_REF: ${{ needs.command.outputs.head_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 .github/scripts/orchestrai_report.py \
+            --artifacts artifacts --run-url "$RUN_URL" --sha "$HEAD_SHA" --ref "$HEAD_REF" > /tmp/body.md
+          python3 -c "import json;print(json.dumps({'body':open('/tmp/body.md').read()}))" > /tmp/payload.json
+          MARKER='<!-- orchestrai-orc-report -->'
+          existing=$(curl -s -H "Authorization: Bearer $GH_TOKEN" "$API/repos/$REPO/issues/$PR/comments?per_page=100" \
+            | python3 -c "import sys,json;c=[x for x in json.load(sys.stdin) if str(x.get('body','')).startswith('$MARKER')];print(c[0]['id'] if c else '')")
+          if [ -n "$existing" ]; then
+            curl -s -X PATCH -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "$API/repos/$REPO/issues/comments/$existing" -d @/tmp/payload.json >/dev/null
+          else
+            curl -s -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "$API/repos/$REPO/issues/$PR/comments" -d @/tmp/payload.json >/dev/null
+          fi
+          echo "Posted results to PR #$PR"

--- a/.github/workflows/orchestrai-pr-command.yml
+++ b/.github/workflows/orchestrai-pr-command.yml
@@ -1,0 +1,264 @@
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+#
+# ChatOps: comment `!orc` on a PR to run that PR's playbooks via OrchestrAI and
+# get a sticky pass/fail comment back.
+#
+#   !orc            -> the playbooks changed in the PR
+#   !orc all        -> every playbook
+#   !orc a,b,c      -> the named playbooks
+#
+# Only users with write access (OWNER/MEMBER/COLLABORATOR) can trigger it, since
+# it runs internal hardware with the OrchestrAI pipeline secrets. issue_comment runs from the
+# default branch, so this file must be on the default branch to take effect.
+
+name: OrchestrAI PR command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: orchestrai-orc-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  command:
+    name: "!orc"
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '!orc') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ${{ vars.ORCHESTRAI_CONTROL_RUNNER || 'ubuntu-latest' }}
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      has_entries: ${{ steps.build-matrix.outputs.has_entries }}
+      build_urls: ${{ steps.trigger.outputs.build_urls }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      head_ref: ${{ steps.pr.outputs.head_ref }}
+    steps:
+      - name: Resolve PR + acknowledge
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API: ${{ github.api_url }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          curl -s -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+            "$API/repos/$REPO/issues/comments/$COMMENT_ID/reactions" -d '{"content":"eyes"}' >/dev/null || true
+          data=$(curl -s -H "Authorization: Bearer $GH_TOKEN" "$API/repos/$REPO/pulls/$PR")
+          py() { printf '%s' "$data" | python3 -c "import sys,json;print(json.load(sys.stdin)$1)"; }
+          # SECURITY: only same-repo PRs. issue_comment carries the repo secrets
+          # even for fork PRs, so allowing forks would let untrusted PR code run
+          # on internal hardware with the OrchestrAI pipeline token. Refuse forks outright.
+          HEAD_REPO_FULL=$(py "['head']['repo']['full_name']")
+          if [ "$HEAD_REPO_FULL" != "$REPO" ]; then
+            echo "fork=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::!orc refused: PR head '$HEAD_REPO_FULL' is a fork of '$REPO'"
+            curl -s -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "$API/repos/$REPO/issues/$PR/comments" \
+              -d '{"body":"🔒 `!orc` is only available for pull requests from branches in this repository, not forks."}' >/dev/null || true
+            exit 0
+          fi
+          {
+            echo "fork=false"
+            echo "head_sha=$(py "['head']['sha']")"
+            echo "base_sha=$(py "['base']['sha']")"
+            echo "head_ref=$(py "['head']['ref']")"
+            echo "head_repo=$(py "['head']['repo']['clone_url']")"
+          } >> "$GITHUB_OUTPUT"
+
+      - if: steps.pr.outputs.fork == 'false'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 0
+
+      - if: steps.pr.outputs.fork == 'false'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+      - if: steps.pr.outputs.fork == 'false'
+        run: pip install --quiet pyyaml
+
+      - name: Require OrchestrAI config
+        if: steps.pr.outputs.fork == 'false'
+        env:
+          JU: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          JT: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: |
+          if [ -z "$JU" ] || [ -z "$JT" ]; then
+            echo "::error::OrchestrAI secrets (ORCHESTRAI_PIPELINE_USER/ORCHESTRAI_PIPELINE_TOKEN) are not set"; exit 1
+          fi
+
+      - name: Parse command into playbook list
+        id: detect
+        if: steps.pr.outputs.fork == 'false'
+        env:
+          BODY: ${{ github.event.comment.body }}
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          arg=$(printf '%s' "$BODY" | head -n1 | sed -E 's/^!orc[[:space:]]*//')
+          if [ "$arg" = "all" ]; then
+            PB=$(find playbooks/core playbooks/supplemental -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sed 's|playbooks/[^/]*/||' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          elif [ -n "$arg" ]; then
+            PB=$(printf '%s' "$arg" | tr ', ' '\n\n' | sed 's/^ *//;s/ *$//' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          else
+            if ! CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- 'playbooks/core/*' 'playbooks/supplemental/*'); then
+              echo "::error::git diff failed (base $BASE_SHA not in history?)"; exit 1
+            fi
+            PB=$(echo "$CHANGED" | grep -E '^playbooks/(core|supplemental)/[^/]+/' | sed 's|playbooks/[^/]*/\([^/]*\)/.*|\1|' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          fi
+          echo "playbooks=${PB:-[]}" >> "$GITHUB_OUTPUT"
+
+      - name: Build matrix and batches
+        id: build-matrix
+        if: steps.pr.outputs.fork == 'false'
+        env:
+          PLAYBOOKS: ${{ steps.detect.outputs.playbooks }}
+          ORCHESTRAI_DEVICE_TAGS: ${{ vars.ORCHESTRAI_DEVICE_TAGS }}
+        run: python3 .github/scripts/orchestrai_matrix.py
+
+      - name: Trigger OrchestrAI pipeline builds (PR code)
+        id: trigger
+        if: steps.pr.outputs.fork == 'false' && steps.build-matrix.outputs.has_entries == 'true'
+        env:
+          BATCHES_JSON: ${{ steps.build-matrix.outputs.batches }}
+          GIT_REF: ${{ steps.pr.outputs.head_ref }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+          ORCHESTRAI_PIPELINE_URL: ${{ secrets.ORCHESTRAI_PIPELINE_URL }}
+          ORCHESTRAI_PIPELINE_JOB: ${{ vars.ORCHESTRAI_PIPELINE_JOB }}
+          ORCHESTRAI_THEROCK_URL: ${{ vars.ORCHESTRAI_THEROCK_URL }}
+          ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL: ${{ vars.ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL }}
+          ORCHESTRAI_LINUX_DRIVER_SOURCE: ${{ vars.ORCHESTRAI_LINUX_DRIVER_SOURCE }}
+          ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON: ${{ vars.ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON }}
+          ORCHESTRAI_RYZENAI_NPU_XRT_URL: ${{ secrets.ORCHESTRAI_RYZENAI_NPU_XRT_URL }}
+          ORCHESTRAI_WINDOWS_DRIVER_SOURCE: ${{ secrets.ORCHESTRAI_WINDOWS_DRIVER_SOURCE }}
+          # Test the PR's own code, not the configured repo@main.
+          ORCHESTRAI_PLAYBOOK_REPO: ${{ steps.pr.outputs.head_repo }}
+          ORCHESTRAI_PLAYBOOK_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: python3 .github/scripts/orchestrai_trigger.py
+
+  test-playbooks:
+    needs: command
+    if: needs.command.outputs.has_entries == 'true'
+    runs-on: ${{ vars.ORCHESTRAI_WAIT_RUNNER || 'ubuntu-latest' }}
+    continue-on-error: ${{ !matrix.required }}
+    strategy:
+      fail-fast: false
+      max-parallel: 16
+      matrix:
+        include: ${{ fromJson(needs.command.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ needs.command.outputs.head_sha }}
+
+      - name: Wait for OrchestrAI pipeline build
+        id: wait
+        env:
+          BUILD_URLS_JSON: ${{ needs.command.outputs.build_urls }}
+          BATCH_ID: ${{ matrix.batch_id }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: |
+          BUILD_URL=$(python3 -c "import json,os;print(json.loads(os.environ.get('BUILD_URLS_JSON','{}') or '{}').get(os.environ['BATCH_ID'],''))")
+          if [ -z "$BUILD_URL" ]; then
+            echo "::error::No OrchestrAI pipeline build URL for batch ${BATCH_ID}"; exit 1
+          fi
+          echo "build_url=${BUILD_URL}" >> "$GITHUB_OUTPUT"
+          echo "Waiting for OrchestrAI pipeline build ..."
+          # SECURITY: pass credentials via a 0600 netrc file, never as `curl -u
+          # user:token` — argv is world-readable (/proc/<pid>/cmdline, ps) for the
+          # life of each curl, which would leak the pipeline token to any other
+          # process on a shared/persistent self-hosted runner. mktemp creates the
+          # file 0600; printf is a shell builtin, so the token never hits argv.
+          NETRC="$(mktemp)"
+          trap 'rm -f "$NETRC"' EXIT
+          NETRC_HOST=$(printf '%s' "$BUILD_URL" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##; s#[:/].*$##')
+          printf 'machine %s login %s password %s\n' \
+            "$NETRC_HOST" "$ORCHESTRAI_PIPELINE_USER" "$ORCHESTRAI_PIPELINE_TOKEN" > "$NETRC"
+          MAX=1080; FAIL_MAX=20; i=0; fails=0
+          while [ "$i" -lt "$MAX" ]; do
+            if data=$(curl -sf --connect-timeout 10 --max-time 30 --netrc-file "$NETRC" "${BUILD_URL}api/json?tree=result,building" 2>/dev/null); then
+              fails=0
+              building=$(echo "$data" | python3 -c "import sys,json;print(json.load(sys.stdin).get('building',True))" 2>/dev/null || echo "True")
+              result=$(echo "$data" | python3 -c "import sys,json;print(json.load(sys.stdin).get('result') or '')" 2>/dev/null || echo "")
+              if [ "$building" = "False" ] && [ -n "$result" ]; then
+                echo "Batch build finished: $result"; break
+              fi
+            else
+              fails=$((fails + 1))
+              if [ "$fails" -ge "$FAIL_MAX" ]; then
+                echo "::error::OrchestrAI pipeline unreachable"; exit 1
+              fi
+            fi
+            i=$((i + 1)); sleep 15
+          done
+          if [ "$i" -ge "$MAX" ]; then echo "::error::Timed out waiting for OrchestrAI pipeline build"; exit 1; fi
+
+      - name: Resolve per-playbook verdict
+        if: always()
+        env:
+          BUILD_URL: ${{ steps.wait.outputs.build_url }}
+          PLAYBOOK_ID: ${{ matrix.playbook }}
+          PLATFORM: ${{ matrix.platform }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: python3 .github/scripts/orchestrai_verdict.py
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-${{ matrix.playbook }}-${{ matrix.platform }}-${{ matrix.arch }}
+          path: test-results/
+          if-no-files-found: ignore
+
+  report:
+    needs: [command, test-playbooks]
+    if: always() && needs.command.result == 'success' && needs.command.outputs.head_sha != ''
+    runs-on: ${{ vars.ORCHESTRAI_CONTROL_RUNNER || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ needs.command.outputs.head_sha }}
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: artifacts
+        continue-on-error: true
+
+      - name: Build + upsert sticky comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API: ${{ github.api_url }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+          HEAD_SHA: ${{ needs.command.outputs.head_sha }}
+          HEAD_REF: ${{ needs.command.outputs.head_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 .github/scripts/orchestrai_report.py \
+            --artifacts artifacts --run-url "$RUN_URL" --sha "$HEAD_SHA" --ref "$HEAD_REF" > /tmp/body.md
+          python3 -c "import json;print(json.dumps({'body':open('/tmp/body.md').read()}))" > /tmp/payload.json
+          MARKER='<!-- orchestrai-orc-report -->'
+          existing=$(curl -s -H "Authorization: Bearer $GH_TOKEN" "$API/repos/$REPO/issues/$PR/comments?per_page=100" \
+            | python3 -c "import sys,json;c=[x for x in json.load(sys.stdin) if str(x.get('body','')).startswith('$MARKER')];print(c[0]['id'] if c else '')")
+          if [ -n "$existing" ]; then
+            curl -s -X PATCH -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "$API/repos/$REPO/issues/comments/$existing" -d @/tmp/payload.json >/dev/null
+          else
+            curl -s -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "$API/repos/$REPO/issues/$PR/comments" -d @/tmp/payload.json >/dev/null
+          fi
+          echo "Posted results to PR #$PR"

--- a/.github/workflows/test-playbooks-orchestrai.yml
+++ b/.github/workflows/test-playbooks-orchestrai.yml
@@ -1,0 +1,272 @@
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+#
+# OrchestrAI playbook CI (opt-in, additive).
+#
+# Runs each playbook on real AMD hardware via the OrchestrAI pipeline (
+# MAAS broker) instead of on a device-attached GitHub runner. It is independent
+# of the native test-playbooks.yml — enable it by providing the secrets/vars
+# below; otherwise it simply no-ops on a fork without them.
+#
+# Required repo secrets:   ORCHESTRAI_PIPELINE_USER, ORCHESTRAI_PIPELINE_TOKEN
+# Optional repo secrets:   ORCHESTRAI_HF_TOKEN — a HuggingFace token passed to
+#   test machines as HF_TOKEN so live HF pulls (dependency cache misses, uncached
+#   datasets) are authenticated and avoid HF's shared-IP rate limit (429).
+# Optional repo variables: ORCHESTRAI_CONTROL_RUNNER (default ubuntu-latest)
+#                          ORCHESTRAI_WAIT_RUNNER    (default ubuntu-latest)
+#   -> set these to runners that can reach the OrchestrAI pipeline URL in
+#      .github/orchestrai-config.yml.
+# Required for Linux Radeon batches: ORCHESTRAI_LINUX_DRIVER_SOURCE points to
+# the approved amdgpu-install package held in repository configuration.
+# Required for ROCm Python dependencies: ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL
+# points to the approved multi-architecture wheel index.
+# All other settings live in .github/orchestrai-config.yml.
+
+name: Test Playbooks (OrchestrAI)
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+    inputs:
+      playbook_id:
+        description: 'Playbook ID(s) to test, comma-separated (empty = all)'
+        required: false
+        type: string
+      device:
+        description: 'Device(s) to test on, comma-separated e.g. stx,halo (empty = all declared devices)'
+        required: false
+        type: string
+      platform:
+        description: 'OS to test on'
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - linux
+          - windows
+      machines_per_hw_group:
+        description: 'Machines per hardware group (1 = same-HW playbooks share one machine, sequential)'
+        required: false
+        type: string
+        default: '1'
+  pull_request:
+    paths:
+      - 'playbooks/**'
+
+permissions:
+  contents: read
+
+# Don't pile up runs on the shared hardware fleet: one run per ref, and cancel
+# superseded PR runs (but never cancel an in-flight scheduled/dispatch run).
+concurrency:
+  # Include the event so a scheduled run and a manual dispatch on the same ref
+  # don't serialize behind each other; PRs still group by PR number.
+  group: orchestrai-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  detect-and-trigger:
+    name: Detect & Trigger
+    runs-on: ${{ vars.ORCHESTRAI_CONTROL_RUNNER || 'ubuntu-latest' }}
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      has_entries: ${{ steps.build-matrix.outputs.has_entries }}
+      build_urls: ${{ steps.trigger.outputs.build_urls }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install deps
+        run: pip install --quiet pyyaml
+
+      - name: Check OrchestrAI is configured
+        id: gate
+        env:
+          JU: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          JT: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: |
+          if [ -n "$JU" ] && [ -n "$JT" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::OrchestrAI secrets (ORCHESTRAI_PIPELINE_USER/ORCHESTRAI_PIPELINE_TOKEN) not set — skipping OrchestrAI run."
+          fi
+
+      - name: Detect playbooks
+        id: detect
+        if: steps.gate.outputs.enabled == 'true'
+        # Pass event data via env (not inline ${{ }}) so untrusted strings never
+        # reach the shell directly.
+        env:
+          PLAYBOOK_INPUT: ${{ github.event.inputs.playbook_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [ -n "$PLAYBOOK_INPUT" ]; then
+            PB=$(echo "$PLAYBOOK_INPUT" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            if ! CHANGED=$(git diff --name-only "$PR_BASE_SHA" "$HEAD_SHA" -- 'playbooks/core/*' 'playbooks/supplemental/*'); then
+              echo "::error::git diff failed (base $PR_BASE_SHA not in history?) — cannot determine changed playbooks"; exit 1
+            fi
+            PB=$(echo "$CHANGED" | grep -E '^playbooks/(core|supplemental)/[^/]+/' | sed 's|playbooks/[^/]*/\([^/]*\)/.*|\1|' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          else
+            PB=$(find playbooks/core playbooks/supplemental -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sed 's|playbooks/[^/]*/||' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          fi
+          echo "playbooks=${PB:-[]}" >> "$GITHUB_OUTPUT"
+
+      - name: Build matrix and batches
+        id: build-matrix
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          PLAYBOOKS: ${{ steps.detect.outputs.playbooks }}
+          ORCHESTRAI_DEVICE_TAGS: ${{ vars.ORCHESTRAI_DEVICE_TAGS }}
+          DEVICES: ${{ inputs.device }}
+          PLATFORMS: ${{ inputs.platform }}
+        run: python3 .github/scripts/orchestrai_matrix.py
+
+      - name: Trigger OrchestrAI pipeline builds
+        id: trigger
+        if: steps.gate.outputs.enabled == 'true' && steps.build-matrix.outputs.has_entries == 'true'
+        env:
+          BATCHES_JSON: ${{ steps.build-matrix.outputs.batches }}
+          GIT_REF: ${{ github.ref }}
+          MACHINES_PER_HW_GROUP: ${{ github.event.inputs.machines_per_hw_group || '' }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+          # Optional HF token so live HuggingFace pulls (dep cache misses,
+          # uncached datasets) are authenticated and avoid the shared-IP 429.
+          ORCHESTRAI_HF_TOKEN: ${{ secrets.ORCHESTRAI_HF_TOKEN }}
+          ORCHESTRAI_PIPELINE_URL: ${{ vars.ORCHESTRAI_PIPELINE_URL }}
+          ORCHESTRAI_PIPELINE_JOB: ${{ vars.ORCHESTRAI_PIPELINE_JOB }}
+          ORCHESTRAI_THEROCK_URL: ${{ vars.ORCHESTRAI_THEROCK_URL }}
+          ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL: ${{ vars.ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL }}
+          ORCHESTRAI_LINUX_DRIVER_SOURCE: ${{ vars.ORCHESTRAI_LINUX_DRIVER_SOURCE }}
+          ORCHESTRAI_RYZENAI_NPU_XRT_URL: ${{ vars.ORCHESTRAI_RYZENAI_NPU_XRT_URL }}
+          ORCHESTRAI_WINDOWS_DRIVER_SOURCE: ${{ vars.ORCHESTRAI_WINDOWS_DRIVER_SOURCE }}
+          # On a pull_request, test the PR's OWN code (same as the !orc path),
+          # not the configured repo@main. These are empty on schedule/dispatch, so
+          # orchestrai_trigger.py falls back to playbook_repo@main there. Fork PRs
+          # never reach this step: the secret gate above is false without secrets.
+          ORCHESTRAI_PLAYBOOK_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
+          ORCHESTRAI_PLAYBOOK_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 .github/scripts/orchestrai_trigger.py
+
+  test-playbooks:
+    name: "Test ${{ matrix.playbook }} (${{ matrix.platform }}/${{ matrix.arch }})${{ matrix.required && ' ✦' || '' }}"
+    needs: detect-and-trigger
+    if: needs.detect-and-trigger.outputs.has_entries == 'true'
+    runs-on: ${{ vars.ORCHESTRAI_WAIT_RUNNER || 'ubuntu-latest' }}
+    continue-on-error: ${{ !matrix.required }}
+    strategy:
+      fail-fast: false
+      max-parallel: 16
+      matrix:
+        include: ${{ fromJson(needs.detect-and-trigger.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Wait for OrchestrAI pipeline build
+        id: wait
+        env:
+          BUILD_URLS_JSON: ${{ needs.detect-and-trigger.outputs.build_urls }}
+          BATCH_ID: ${{ matrix.batch_id }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: |
+          BUILD_URL=$(python3 -c "import json,os;print(json.loads(os.environ.get('BUILD_URLS_JSON','{}') or '{}').get(os.environ['BATCH_ID'],''))")
+          if [ -z "$BUILD_URL" ]; then
+            echo "::error::No OrchestrAI pipeline build URL for batch ${BATCH_ID}"; exit 1
+          fi
+          echo "build_url=${BUILD_URL}" >> "$GITHUB_OUTPUT"
+          echo "Waiting for OrchestrAI pipeline build ..."
+          # Bounded poll: ~4.5h cap (1080 * 15s) — covers max_duration (240m) plus
+          # provisioning/queue, but never hangs to the GitHub job timeout.
+          MAX=1080          # ~4.5h cap (1080 * 15s) — covers max_duration + queue
+          FAIL_MAX=20       # ~5min of consecutive unreachable polls -> give up
+          i=0; fails=0
+          while [ "$i" -lt "$MAX" ]; do
+            if data=$(curl -sf --connect-timeout 10 --max-time 30 -u "${ORCHESTRAI_PIPELINE_USER}:${ORCHESTRAI_PIPELINE_TOKEN}" "${BUILD_URL}api/json?tree=result,building" 2>/dev/null); then
+              fails=0
+              building=$(echo "$data" | python3 -c "import sys,json;print(json.load(sys.stdin).get('building',True))" 2>/dev/null || echo "True")
+              result=$(echo "$data" | python3 -c "import sys,json;print(json.load(sys.stdin).get('result') or '')" 2>/dev/null || echo "")
+              # The batch result reflects ALL its playbooks; this job's verdict is
+              # resolved per-playbook in the next step from summary.json.
+              if [ "$building" = "False" ] && [ -n "$result" ]; then
+                echo "Batch build finished: $result (per-playbook verdict resolved next)"; break
+              fi
+            else
+              fails=$((fails + 1))
+              if [ "$fails" -ge "$FAIL_MAX" ]; then
+                echo "::error::OrchestrAI pipeline unreachable ($FAIL_MAX consecutive failures)"; exit 1
+              fi
+            fi
+            i=$((i + 1))
+            sleep 15
+          done
+          if [ "$i" -ge "$MAX" ]; then
+            echo "::error::Timed out waiting for OrchestrAI pipeline build"; exit 1
+          fi
+
+      - name: Resolve per-playbook verdict
+        if: always()
+        id: results
+        env:
+          BUILD_URL: ${{ steps.wait.outputs.build_url }}
+          PLAYBOOK_ID: ${{ matrix.playbook }}
+          PLATFORM: ${{ matrix.platform }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: python3 .github/scripts/orchestrai_verdict.py
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-${{ matrix.playbook }}-${{ matrix.platform }}-${{ matrix.arch }}
+          path: test-results/
+          if-no-files-found: ignore
+
+      - name: Test summary
+        if: always()
+        env:
+          RP_URL: ${{ steps.results.outputs.rp_url }}
+        run: |
+          {
+            echo "### \`${{ matrix.playbook }}\` (${{ matrix.platform }}/${{ matrix.arch }})"
+            echo ""
+            # Link to ReportPortal (test results) only. The pipeline build URL is
+            # intentionally not shown here.
+            if [ -n "${RP_URL}" ]; then
+              echo "| | |"; echo "|---|---|"
+              echo "| ReportPortal | [View Results](${RP_URL}) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  test-gate:
+    name: Test Gate (Required)
+    needs: [detect-and-trigger, test-playbooks]
+    if: always()
+    runs-on: ${{ vars.ORCHESTRAI_CONTROL_RUNNER || 'ubuntu-latest' }}
+    steps:
+      - name: Check required tests
+        run: |
+          echo "detect-and-trigger: ${{ needs.detect-and-trigger.result }}"
+          echo "test-playbooks:     ${{ needs.test-playbooks.result }}"
+          # A failure in detect/matrix/trigger skips test-playbooks, so gate on it
+          # too — otherwise a trigger failure would leave this required check green.
+          if [ "${{ needs.detect-and-trigger.result }}" = "failure" ]; then
+            echo "::error::Detect/trigger failed — the pipeline did not run"; exit 1
+          fi
+          if [ "${{ needs.test-playbooks.result }}" = "failure" ]; then
+            echo "::error::One or more required tests failed"; exit 1
+          fi
+          echo "All required tests passed (or none were needed)"

--- a/.github/workflows/test-playbooks-orchestrai.yml
+++ b/.github/workflows/test-playbooks-orchestrai.yml
@@ -1,0 +1,288 @@
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+#
+# OrchestrAI playbook CI (opt-in, additive).
+#
+# Runs each playbook on real AMD hardware via the OrchestrAI pipeline (
+# MAAS broker) instead of on a device-attached GitHub runner. It is independent
+# of the native test-playbooks.yml — enable it by providing the secrets/vars
+# below; otherwise it simply no-ops on a fork without them.
+#
+# Required repo secrets:   ORCHESTRAI_PIPELINE_USER, ORCHESTRAI_PIPELINE_TOKEN
+# Optional repo secrets:   ORCHESTRAI_HF_TOKEN — a HuggingFace token passed to
+#   test machines as HF_TOKEN so live HF pulls (dependency cache misses, uncached
+#   datasets) are authenticated and avoid HF's shared-IP rate limit (429).
+# Optional repo variables: ORCHESTRAI_CONTROL_RUNNER (default ubuntu-latest)
+#                          ORCHESTRAI_WAIT_RUNNER    (default ubuntu-latest)
+#   -> set these to runners that can reach the OrchestrAI pipeline URL in
+#      .github/orchestrai-config.yml.
+# Required for Linux Radeon batches: ORCHESTRAI_LINUX_DRIVER_SOURCE points to
+# the approved amdgpu-install package held in repository configuration.
+# Required for ROCm Python dependencies: ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL
+# points to the approved multi-architecture wheel index.
+# All other settings live in .github/orchestrai-config.yml.
+
+name: Test Playbooks (OrchestrAI)
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+    inputs:
+      playbook_id:
+        description: 'Playbook ID(s) to test, comma-separated (empty = all)'
+        required: false
+        type: string
+      device:
+        description: 'Device(s) to test on, comma-separated e.g. stx,halo (empty = all declared devices)'
+        required: false
+        type: string
+      platform:
+        description: 'OS to test on'
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - linux
+          - windows
+      machines_per_hw_group:
+        description: 'Machines per hardware group (1 = same-HW playbooks share one machine, sequential)'
+        required: false
+        type: string
+        default: '1'
+  # No pull_request trigger: PR runs are opt-in, not automatic on every push, to
+  # keep the shared hardware fleet from being flooded. To test a PR, comment
+  # `!orc` on it (see orchestrai-pr-command.yml) — that runs the PR's own head
+  # commit on demand. Re-enable auto-runs by adding a `pull_request:` block here;
+  # the detect step already handles the pull_request event (changed-playbooks
+  # diff) and the trigger step already sets PLAYBOOK_REPO/SHA from the PR head.
+
+permissions:
+  contents: read
+
+# Don't pile up runs on the shared hardware fleet: one run per ref, and cancel
+# superseded PR runs (but never cancel an in-flight scheduled/dispatch run).
+concurrency:
+  # Include the event so a scheduled run and a manual dispatch on the same ref
+  # don't serialize behind each other; PRs still group by PR number.
+  group: orchestrai-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  detect-and-trigger:
+    name: Detect & Trigger
+    runs-on: ${{ vars.ORCHESTRAI_CONTROL_RUNNER || 'ubuntu-latest' }}
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      has_entries: ${{ steps.build-matrix.outputs.has_entries }}
+      build_urls: ${{ steps.trigger.outputs.build_urls }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Install deps
+        run: pip install --quiet pyyaml
+
+      - name: Check OrchestrAI is configured
+        id: gate
+        env:
+          JU: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          JT: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: |
+          if [ -n "$JU" ] && [ -n "$JT" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::OrchestrAI secrets (ORCHESTRAI_PIPELINE_USER/ORCHESTRAI_PIPELINE_TOKEN) not set — skipping OrchestrAI run."
+          fi
+
+      - name: Detect playbooks
+        id: detect
+        if: steps.gate.outputs.enabled == 'true'
+        # Pass event data via env (not inline ${{ }}) so untrusted strings never
+        # reach the shell directly.
+        env:
+          PLAYBOOK_INPUT: ${{ github.event.inputs.playbook_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [ -n "$PLAYBOOK_INPUT" ]; then
+            PB=$(echo "$PLAYBOOK_INPUT" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            if ! CHANGED=$(git diff --name-only "$PR_BASE_SHA" "$HEAD_SHA" -- 'playbooks/core/*' 'playbooks/supplemental/*'); then
+              echo "::error::git diff failed (base $PR_BASE_SHA not in history?) — cannot determine changed playbooks"; exit 1
+            fi
+            PB=$(echo "$CHANGED" | grep -E '^playbooks/(core|supplemental)/[^/]+/' | sed 's|playbooks/[^/]*/\([^/]*\)/.*|\1|' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          else
+            PB=$(find playbooks/core playbooks/supplemental -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sed 's|playbooks/[^/]*/||' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          fi
+          echo "playbooks=${PB:-[]}" >> "$GITHUB_OUTPUT"
+
+      - name: Build matrix and batches
+        id: build-matrix
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          PLAYBOOKS: ${{ steps.detect.outputs.playbooks }}
+          ORCHESTRAI_DEVICE_TAGS: ${{ vars.ORCHESTRAI_DEVICE_TAGS }}
+          DEVICES: ${{ inputs.device }}
+          PLATFORMS: ${{ inputs.platform }}
+        run: python3 .github/scripts/orchestrai_matrix.py
+
+      - name: Trigger OrchestrAI pipeline builds
+        id: trigger
+        if: steps.gate.outputs.enabled == 'true' && steps.build-matrix.outputs.has_entries == 'true'
+        env:
+          BATCHES_JSON: ${{ steps.build-matrix.outputs.batches }}
+          GIT_REF: ${{ github.ref }}
+          MACHINES_PER_HW_GROUP: ${{ github.event.inputs.machines_per_hw_group || '' }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+          # Optional HF token so live HuggingFace pulls (dep cache misses,
+          # uncached datasets) are authenticated and avoid the shared-IP 429.
+          ORCHESTRAI_HF_TOKEN: ${{ secrets.ORCHESTRAI_HF_TOKEN }}
+          ORCHESTRAI_PIPELINE_URL: ${{ secrets.ORCHESTRAI_PIPELINE_URL }}
+          ORCHESTRAI_PIPELINE_JOB: ${{ vars.ORCHESTRAI_PIPELINE_JOB }}
+          ORCHESTRAI_THEROCK_URL: ${{ vars.ORCHESTRAI_THEROCK_URL }}
+          ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL: ${{ vars.ORCHESTRAI_ROCM_MULTI_ARCH_INDEX_URL }}
+          ORCHESTRAI_LINUX_DRIVER_SOURCE: ${{ vars.ORCHESTRAI_LINUX_DRIVER_SOURCE }}
+          # Optional per-release amdgpu map; overrides the single URL above on
+          # hosts whose release has an entry.
+          ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON: ${{ vars.ORCHESTRAI_LINUX_DRIVER_SOURCES_JSON }}
+          ORCHESTRAI_RYZENAI_NPU_XRT_URL: ${{ secrets.ORCHESTRAI_RYZENAI_NPU_XRT_URL }}
+          ORCHESTRAI_WINDOWS_DRIVER_SOURCE: ${{ secrets.ORCHESTRAI_WINDOWS_DRIVER_SOURCE }}
+          # On a pull_request, test the PR's OWN code (same as the !orc path),
+          # not the configured repo@main. These are empty on schedule/dispatch, so
+          # orchestrai_trigger.py falls back to playbook_repo@main there. Fork PRs
+          # never reach this step: the secret gate above is false without secrets.
+          ORCHESTRAI_PLAYBOOK_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
+          ORCHESTRAI_PLAYBOOK_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 .github/scripts/orchestrai_trigger.py
+
+  test-playbooks:
+    name: "Test ${{ matrix.playbook }} (${{ matrix.platform }}/${{ matrix.arch }})${{ matrix.required && ' ✦' || '' }}"
+    needs: detect-and-trigger
+    if: needs.detect-and-trigger.outputs.has_entries == 'true'
+    runs-on: ${{ vars.ORCHESTRAI_WAIT_RUNNER || 'ubuntu-latest' }}
+    continue-on-error: ${{ !matrix.required }}
+    strategy:
+      fail-fast: false
+      max-parallel: 16
+      matrix:
+        include: ${{ fromJson(needs.detect-and-trigger.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Wait for OrchestrAI pipeline build
+        id: wait
+        env:
+          BUILD_URLS_JSON: ${{ needs.detect-and-trigger.outputs.build_urls }}
+          BATCH_ID: ${{ matrix.batch_id }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: |
+          BUILD_URL=$(python3 -c "import json,os;print(json.loads(os.environ.get('BUILD_URLS_JSON','{}') or '{}').get(os.environ['BATCH_ID'],''))")
+          if [ -z "$BUILD_URL" ]; then
+            echo "::error::No OrchestrAI pipeline build URL for batch ${BATCH_ID}"; exit 1
+          fi
+          echo "build_url=${BUILD_URL}" >> "$GITHUB_OUTPUT"
+          echo "Waiting for OrchestrAI pipeline build ..."
+          # SECURITY: pass credentials via a 0600 netrc file, never as `curl -u
+          # user:token` — argv is world-readable (/proc/<pid>/cmdline, ps) for the
+          # life of each curl, which would leak the pipeline token to any other
+          # process on a shared/persistent self-hosted runner. mktemp creates the
+          # file 0600; printf is a shell builtin, so the token never hits argv.
+          NETRC="$(mktemp)"
+          trap 'rm -f "$NETRC"' EXIT
+          NETRC_HOST=$(printf '%s' "$BUILD_URL" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##; s#[:/].*$##')
+          printf 'machine %s login %s password %s\n' \
+            "$NETRC_HOST" "$ORCHESTRAI_PIPELINE_USER" "$ORCHESTRAI_PIPELINE_TOKEN" > "$NETRC"
+          # Bounded poll: ~4.5h cap (1080 * 15s) — covers max_duration (240m) plus
+          # provisioning/queue, but never hangs to the GitHub job timeout.
+          MAX=1080          # ~4.5h cap (1080 * 15s) — covers max_duration + queue
+          FAIL_MAX=20       # ~5min of consecutive unreachable polls -> give up
+          i=0; fails=0
+          while [ "$i" -lt "$MAX" ]; do
+            if data=$(curl -sf --connect-timeout 10 --max-time 30 --netrc-file "$NETRC" "${BUILD_URL}api/json?tree=result,building" 2>/dev/null); then
+              fails=0
+              building=$(echo "$data" | python3 -c "import sys,json;print(json.load(sys.stdin).get('building',True))" 2>/dev/null || echo "True")
+              result=$(echo "$data" | python3 -c "import sys,json;print(json.load(sys.stdin).get('result') or '')" 2>/dev/null || echo "")
+              # The batch result reflects ALL its playbooks; this job's verdict is
+              # resolved per-playbook in the next step from summary.json.
+              if [ "$building" = "False" ] && [ -n "$result" ]; then
+                echo "Batch build finished: $result (per-playbook verdict resolved next)"; break
+              fi
+            else
+              fails=$((fails + 1))
+              if [ "$fails" -ge "$FAIL_MAX" ]; then
+                echo "::error::OrchestrAI pipeline unreachable ($FAIL_MAX consecutive failures)"; exit 1
+              fi
+            fi
+            i=$((i + 1))
+            sleep 15
+          done
+          if [ "$i" -ge "$MAX" ]; then
+            echo "::error::Timed out waiting for OrchestrAI pipeline build"; exit 1
+          fi
+
+      - name: Resolve per-playbook verdict
+        if: always()
+        id: results
+        env:
+          BUILD_URL: ${{ steps.wait.outputs.build_url }}
+          PLAYBOOK_ID: ${{ matrix.playbook }}
+          PLATFORM: ${{ matrix.platform }}
+          ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
+          ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
+        run: python3 .github/scripts/orchestrai_verdict.py
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-${{ matrix.playbook }}-${{ matrix.platform }}-${{ matrix.arch }}
+          path: test-results/
+          if-no-files-found: ignore
+
+      - name: Test summary
+        if: always()
+        env:
+          RP_URL: ${{ steps.results.outputs.rp_url }}
+        run: |
+          {
+            echo "### \`${{ matrix.playbook }}\` (${{ matrix.platform }}/${{ matrix.arch }})"
+            echo ""
+            # Link to ReportPortal (test results) only. The pipeline build URL is
+            # intentionally not shown here.
+            if [ -n "${RP_URL}" ]; then
+              echo "| | |"; echo "|---|---|"
+              echo "| ReportPortal | [View Results](${RP_URL}) |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  test-gate:
+    name: Test Gate (Required)
+    needs: [detect-and-trigger, test-playbooks]
+    if: always()
+    runs-on: ${{ vars.ORCHESTRAI_CONTROL_RUNNER || 'ubuntu-latest' }}
+    steps:
+      - name: Check required tests
+        run: |
+          echo "detect-and-trigger: ${{ needs.detect-and-trigger.result }}"
+          echo "test-playbooks:     ${{ needs.test-playbooks.result }}"
+          # A failure in detect/matrix/trigger skips test-playbooks, so gate on it
+          # too — otherwise a trigger failure would leave this required check green.
+          if [ "${{ needs.detect-and-trigger.result }}" = "failure" ]; then
+            echo "::error::Detect/trigger failed — the pipeline did not run"; exit 1
+          fi
+          if [ "${{ needs.test-playbooks.result }}" = "failure" ]; then
+            echo "::error::One or more required tests failed"; exit 1
+          fi
+          echo "All required tests passed (or none were needed)"


### PR DESCRIPTION
Additive, opt-in workflow that runs each playbook on real AMD hardware via the OrchestrAI pipeline independent of the existing native-runner test-playbooks.yml.

Adds (7 files, nothing modified/removed):

    .github/workflows/test-playbooks-orchestrai.yml scheduled / PR / dispatch runs
    .github/workflows/orchestrai-pr-command.yml !orc PR ChatOps trigger
    .github/scripts/orchestrai_matrix.py build the run matrix + batches
    .github/scripts/orchestrai_trigger.py trigger the OrchestrAI pipeline (--dry-run)
    .github/scripts/orchestrai_verdict.py per-playbook pass/fail verdict
    .github/scripts/orchestrai_report.py !orc sticky PR-comment report
    .github/orchestrai-config.yml non-secret configuration

How it works: detect playbooks (changed on PR / all on schedule / given on dispatch) → build a matrix from each playbook.json → group by hardware into batches → one OrchestrAI pipeline build per batch (same-HW playbooks share a machine) → resolve each playbook's verdict from the build's summary.json groups.

Enablement: set the pipeline credential secrets and ORCHESTRAI_* repo variables (pipeline URL/job, TheRock URL template, Windows driver source, optional runner labels, device tags). Absent secrets ⇒ the run skips cleanly, so forks are unaffected.