### PR TITLE
unsloth: fail install-deps on pip error (Windows)

### DIFF
--- a/playbooks/supplemental/unsloth-llms-finetuning/README.md
+++ b/playbooks/supplemental/unsloth-llms-finetuning/README.md
@@ -157,8 +157,11 @@ pip install "unsloth[amd] @ git+https://github.com/unslothai/unsloth.git"
 <!-- @os:windows -->
 <!-- @test:id=install-deps timeout=600 setup=activate-venv -->
 ```powershell
+$ErrorActionPreference = "Stop"
 pip install "unsloth[amd] @ git+https://github.com/unslothai/unsloth.git"
+if ($LASTEXITCODE -ne 0) { throw "unsloth install failed" }
 pip install triton-windows
+if ($LASTEXITCODE -ne 0) { throw "triton-windows install failed" }
 ```
 <!-- @test:end -->
 <!-- @os:end -->

--- a/playbooks/supplemental/unsloth-llms-finetuning/README.md
+++ b/playbooks/supplemental/unsloth-llms-finetuning/README.md
@@ -157,11 +157,7 @@ pip install "unsloth[amd] @ git+https://github.com/unslothai/unsloth.git"
 <!-- @os:windows -->
 <!-- @test:id=install-deps timeout=600 setup=activate-venv -->
 ```powershell
-$ErrorActionPreference = "Stop"
-pip install "unsloth[amd] @ git+https://github.com/unslothai/unsloth.git"
-if ($LASTEXITCODE -ne 0) { throw "unsloth install failed" }
-pip install triton-windows
-if ($LASTEXITCODE -ne 0) { throw "triton-windows install failed" }
+pip install "unsloth[amd] @ git+https://github.com/unslothai/unsloth.git" triton-windows
 ```
 <!-- @test:end -->
 <!-- @os:end -->


### PR DESCRIPTION
The Windows `install-deps` block runs two pip installs. If the first (`unsloth[amd] @ git+…`) fails, the second (`triton-windows`) masks it and the block exits 0 — so a failed install surfaces later as a confusing `verify-imports` *'No module named unsloth'* (e.g. #675, #567) instead of a clear install-deps failure.

Fix: `$ErrorActionPreference='Stop'` + explicit `$LASTEXITCODE` checks after each pip so a pip failure fails the step.

Refs #675.