### PR TITLE
orchestrai(!orc): don't let unrelated PR comments cancel a running !orc

### DIFF
--- a/.github/workflows/orchestrai-pr-command.yml
+++ b/.github/workflows/orchestrai-pr-command.yml
@@ -25,8 +25,13 @@ permissions:
   issues: write
 
 concurrency:
-  group: orchestrai-orc-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  # Only real `!orc` runs share the per-PR group so a newer `!orc` supersedes an
+  # older one. Every OTHER issue_comment on the PR (a human reply, the bot's own
+  # status comment, an unauthorized commenter) gets its own throwaway group and
+  # cannot cancel an in-flight `!orc` — previously they all shared this group with
+  # cancel-in-progress:true, so any stray comment killed a running `!orc`.
+  group: ${{ startsWith(github.event.comment.body, '!orc') && format('orchestrai-orc-{0}', github.event.issue.number) || format('orchestrai-orc-other-{0}', github.event.comment.id) }}
+  cancel-in-progress: ${{ startsWith(github.event.comment.body, '!orc') }}
 
 jobs:
   command:


### PR DESCRIPTION
## Problem
`!orc` runs get cancelled mid-wait — "The operation was canceled", then an empty verdict (`groups present: []`) — when another comment lands on the PR while `!orc` is running.

## Cause
Workflow-level concurrency covers **every** `issue_comment` on the PR (not just `!orc`) with `cancel-in-progress: true`:
```yaml
group: orchestrai-orc-${{ github.event.issue.number }}
cancel-in-progress: true
```
So a later comment (human reply, unauthorized commenter, or the bot's own status comment) enters the same group and cancels the in-flight `!orc`.

## Fix
- **`!orc`** → `orchestrai-orc-<PR>`, `cancel-in-progress: true` (a newer `!orc` still supersedes an older one)
- **any other comment** → a unique per-comment group with `cancel-in-progress: false` — can never cancel a running `!orc` (its job skips anyway)

Config-only, single file.
