### PR TITLE
orchestrai(!orc): put per-playbook ReportPortal links in the PR comment

### DIFF
--- a/.github/scripts/orchestrai_report.py
+++ b/.github/scripts/orchestrai_report.py
@@ -56,7 +56,8 @@ def main():
         passed = int(d.get("passed", 0) or 0)
         failed = int(d.get("failed", 0) or 0)
         ok = failed == 0 and passed > 0
-        rows.append((pb, platform, arch, ok))
+        rp = d.get("rp_launch_url", "") or ""
+        rows.append((pb, platform, arch, ok, rp))
 
     rows.sort(key=lambda r: (r[0], r[1], r[2]))
     n_pass = sum(1 for r in rows if r[3])
@@ -66,9 +67,10 @@ def main():
 
     lines = [MARKER, f"### OrchestrAI results — {overall} ({n_pass} passed, {n_fail} failed)", ""]
     if rows:
-        lines += ["| Playbook | Platform | Device | Result |", "|---|---|---|---|"]
-        for pb, platform, arch, ok in rows:
-            lines.append(f"| `{pb}` | {platform} | {arch} | {'✅ pass' if ok else '❌ fail'} |")
+        lines += ["| Playbook | Platform | Device | Result | Results |", "|---|---|---|---|---|"]
+        for pb, platform, arch, ok, rp in rows:
+            report = f"[ReportPortal]({rp})" if rp else "—"
+            lines.append(f"| `{pb}` | {platform} | {arch} | {'✅ pass' if ok else '❌ fail'} | {report} |")
     else:
         lines.append("_No playbooks were scheduled (nothing matched, or all devices were skipped)._")
     lines.append("")
@@ -76,7 +78,7 @@ def main():
     if args.sha:
         foot.append(f"tested `{args.sha[:8]}`" + (f" ({args.ref})" if args.ref else ""))
     if args.run_url:
-        foot.append(f"[workflow run]({args.run_url}) — per-playbook ReportPortal links are in each job summary")
+        foot.append(f"[workflow run]({args.run_url})")
     if foot:
         lines.append(" · ".join(foot))
 

--- a/.github/scripts/orchestrai_verdict.py
+++ b/.github/scripts/orchestrai_verdict.py
@@ -107,11 +107,14 @@ def main():
     group_key = f"playbook-{playbook}"
     os.makedirs("test-results", exist_ok=True)
 
-    def write_summary(ok):
+    def write_summary(ok, rp_url=""):
+        # rp_launch_url is carried in the uploaded artifact so the PR-comment
+        # report (orchestrai_report.py) can render a per-playbook ReportPortal
+        # link — the only place a !orc user can reach the results.
         json.dump(
             {"playbook_id": playbook, "platform": platform, "total_tests": 1,
              "passed": 1 if ok else 0, "failed": 0 if ok else 1,
-             "skipped": 0, "results": []},
+             "skipped": 0, "results": [], "rp_launch_url": rp_url},
             open("test-results/summary.json", "w"), indent=2)
 
     if not build_url:
@@ -125,10 +128,11 @@ def main():
     except Exception:
         summary = {}
 
+    rp_url = summary.get("rp_launch_url", "")
     out = os.environ.get("GITHUB_OUTPUT")
     if out:
         with open(out, "a") as f:
-            f.write(f"rp_url={summary.get('rp_launch_url', '')}\n")
+            f.write(f"rp_url={rp_url}\n")
 
     # Primary: per-group rollup in summary.json.
     status, how = None, ""
@@ -146,7 +150,7 @@ def main():
             how = "console suite lifecycle"
 
     if status is None:
-        write_summary(False)
+        write_summary(False, rp_url)
         groups_present = list((summary.get("groups") or {}).keys())
         print(f"::error::No verdict for {playbook} ({platform}): "
               f"no groups['{group_key}'] in summary.json and no suite result in the "
@@ -154,7 +158,7 @@ def main():
         sys.exit(1)
 
     ok = (status == "PASSED")
-    write_summary(ok)
+    write_summary(ok, rp_url)
     counts = {k: grp.get(k) for k in COUNT_KEYS} if isinstance(grp, dict) else {}
     print(f"{playbook} ({platform}): {'PASS' if ok else 'FAIL'} "
           f"(status={status}, via {how}, counts={counts})")


### PR DESCRIPTION
## Problem
No easy way to reach ReportPortal from an `!orc` run. The sticky comment footer claimed "ReportPortal links are in each job summary", but the `!orc` jobs never write them — so the link was effectively unreachable, worst when a run fails.

## Fix
- `verdict.py` carries the build's RP launch URL in the uploaded `test-results/summary.json` (`rp_launch_url`), including on the no-build / no-verdict failure paths.
- `report.py` renders a per-row **Results → [ReportPortal]** link in the sticky comment.

```
| Playbook | Platform | Device | Result | Results |
|---|---|---|---|---|
| `pytorch-rocm-llms` | linux | r9700 | ❌ fail | [ReportPortal](…/launches/all/…) |
```
One click from the PR, per playbook/device, even on failures.
