### PR TITLE
orchestrai: allow skipping a playbook on a specific device

### DIFF
--- a/.github/orchestrai-config.yml
+++ b/.github/orchestrai-config.yml
@@ -172,6 +172,26 @@ extra_install_scripts:
 # Devices to skip entirely (e.g. temporarily offline hardware).
 skip_devices: ["krk"]
 
+# Skip ONE playbook on ONE device, where skip_devices would be too broad: the
+# device works fine for everything else. Keyed by playbook id -> device list.
+#
+# hermes-lemonade-server and openclaw-lemonade-server both pin a fixed
+# Qwen3.6-35B-A3B-GGUF. Lemonade refuses any model above 80% of system RAM, so on
+# a 32 GB stx (29 GB usable) the ceiling is 23.2 GB and the model needs 23.3 GB:
+#   "Model 'Qwen3.6-35B-A3B-GGUF' is not available on this system. This model
+#    requires approximately 23.3 GB of memory, but your system only has 29.0 GB
+#    of RAM. Models larger than 23.2 GB (80% of system RAM) are filtered out."
+# `lemonade load` fails before GPU+CPU offload is ever considered. It misses by
+# 0.1 GB, so it presents as flaky rather than broken -- an stx reporting 30 GB
+# gets a 24.0 GB ceiling and passes.
+#
+# Every stx in the farm is currently 32 GB. REMOVE these entries when either
+# lands: 64 GB stx machines, or a device-scoped @var model for stx (note the
+# tests also require ctx_size=262144, so a smaller model alone may not suffice).
+skip_playbook_devices:
+  hermes-lemonade-server:  ["stx"]
+  openclaw-lemonade-server: ["stx"]
+
 # ---------------------------------------------------------------------------
 # Per-run pipeline settings
 # ---------------------------------------------------------------------------

--- a/.github/scripts/orchestrai_matrix.py
+++ b/.github/scripts/orchestrai_matrix.py
@@ -49,6 +49,7 @@ def build(playbooks, cfg, devices=None, platforms=None):
     extra_tag_devices = cfg.get("extra_tag_devices", {})
     extra_devices = cfg.get("extra_devices", {})
     skip_devices = set(cfg.get("skip_devices", []))
+    skip_playbook_devices = cfg.get("skip_playbook_devices", {}) or {}
 
     matrix = []
 
@@ -111,6 +112,25 @@ def build(playbooks, cfg, devices=None, platforms=None):
 
     # 3) Skip offline/unsupported devices
     matrix = [e for e in matrix if e["arch"] not in skip_devices]
+
+    # 3b) Skip a specific playbook on a specific device. Unlike skip_devices
+    #     (the device is unusable for everything), this is for a device that is
+    #     fine in general but cannot run one playbook -- e.g. a playbook pinned
+    #     to a model too large for that SKU's memory. Announce each drop: a
+    #     silently missing combination is indistinguishable from one that was
+    #     never declared.
+    dropped = [
+        (e["playbook"], e["arch"])
+        for e in matrix
+        if e["arch"] in skip_playbook_devices.get(e["playbook"], [])
+    ]
+    for pb_id, device in sorted(set(dropped)):
+        print(f"::notice::skipping playbook '{pb_id}' on device '{device}' "
+              f"(skip_playbook_devices in orchestrai-config.yml)", file=sys.stderr)
+    matrix = [
+        e for e in matrix
+        if e["arch"] not in skip_playbook_devices.get(e["playbook"], [])
+    ]
 
     # 4) Drop batches that request an extra tag the device can't satisfy
     #    (e.g. ram_128gb on a non-128GB device — broker could never match it).


### PR DESCRIPTION
Adds `skip_playbook_devices` to the OrchestrAI config so a single playbook can be excluded from a single device, and uses it to stop scheduling the two Qwen3.6-35B playbooks on 32 GB Strix Point.

## The problem

`hermes-lemonade-server` and `openclaw-lemonade-server` both pin a fixed `Qwen3.6-35B-A3B-GGUF`. Lemonade refuses any model above 80% of system RAM, so on a 32 GB Strix Point (29 GB usable) the ceiling is 23.2 GB and the model needs 23.3 GB:

```
Model 'Qwen3.6-35B-A3B-GGUF' is not available on this system. This model requires
approximately 23.3 GB of memory, but your system only has 29.0 GB of RAM.
Models larger than 23.2 GB (80% of system RAM) are filtered out.
```

`lemonade load` fails before GPU+CPU offload is ever considered, so the playbook's first test fails and the remaining six are skipped.

It misses by **0.1 GB**, which is why it reads as flaky rather than broken — a machine reporting 30 GB gets a 24.0 GB ceiling and passes.

## Why a new key

`skip_devices` is all-or-nothing per device. That is correct when the hardware is unusable, and wrong here: Strix Point runs the other 22 playbooks fine. There was no way to say "skip this playbook on this device", so this adds one:

```yaml
skip_playbook_devices:
  hermes-lemonade-server:   ["stx"]
  openclaw-lemonade-server: ["stx"]
```

Applied in `orchestrai_matrix.py` immediately after `skip_devices`. Each drop emits a `::notice::` — a combination that silently disappears from the matrix is indistinguishable from one that was never declared.

Additive: the key is optional and defaults to `{}`, so a config without it behaves exactly as before.

## Verification

Full 24-playbook matrix, this branch against `main`:

| | entries |
|---|---|
| `main` | 162 |
| this branch | **158** |

Removed: `hermes-lemonade-server` and `openclaw-lemonade-server` × `stx` × {linux, windows}. Nothing added, no other entry altered.

```
::notice::skipping playbook 'hermes-lemonade-server' on device 'stx' (skip_playbook_devices in orchestrai-config.yml)
::notice::skipping playbook 'openclaw-lemonade-server' on device 'stx' (skip_playbook_devices in orchestrai-config.yml)
```

## Removal condition

The two entries are temporary and the config comment records why. Drop them when either lands:

- **Larger Strix Point machines** — every one in the fleet is currently 32 GB.
- **A device-scoped model** — `run_playbook_tests.py` already supports `@var:id=... device=... value=...`, which `pytorch-rocm-llms` and `lmstudio-rocm-llms` both use. Note the tests also require `ctx_size=262144`, so a smaller model alone may not be enough on a 29 GB machine; that needs measuring first.

The mechanism itself is general and stays regardless.