### PR TITLE
omit memory config from dGPUS

### DIFF
--- a/playbooks/core/comfyui-image-gen/README.md
+++ b/playbooks/core/comfyui-image-gen/README.md
@@ -22,9 +22,11 @@ This tutorial teaches you how to use ComfyUI with the Z Image Turbo model on you
 - Generating images and tuning generation parameters
 - Saving and sharing workflows
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/core/comfyui-image-gen/playbook.json
+++ b/playbooks/core/comfyui-image-gen/playbook.json
@@ -107,7 +107,7 @@
   },
   "difficulty": "beginner",
   "isNew": false,
-  "isFeatured": true,
+  "isFeatured": false,
   "developed": true,
   "published": true,
   "tags": [

--- a/playbooks/core/lmstudio-rocm-llms/README.md
+++ b/playbooks/core/lmstudio-rocm-llms/README.md
@@ -20,9 +20,11 @@ LM Studio is a powerful GUI-based wrapper for [llama.cpp](https://github.com/ggm
 - Serve models via OpenAI Compatible API to power custom workflows and apps
 
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/core/n8n-automation-gpt-oss/README.md
+++ b/playbooks/core/n8n-automation-gpt-oss/README.md
@@ -35,9 +35,11 @@ In this playbook, we use Lemonade to serve a local LLM that n8n connects to for 
 
 n8n includes a **native Lemonade node** (`Lemonade Chat Model`) that provides a first-class integration - no need for manual configuration. This makes connecting your local LLM to automation workflows straightforward.
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/core/pytorch-rocm-llms/README.md
+++ b/playbooks/core/pytorch-rocm-llms/README.md
@@ -20,9 +20,11 @@ This tutorial uses PyTorch powered by AMD ROCm™ software to run models that ca
 - Run LLMs like gpt-oss-20b and qwen3.5-4B locally using PyTorch and ROCm
 - Create a document summarization tool using LLMs
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/core/vscode-qwen3-coder/README.md
+++ b/playbooks/core/vscode-qwen3-coder/README.md
@@ -26,9 +26,11 @@ This tutorial demonstrates how to use Cline, VS Code, and LM Studio to run a cod
 * How to configure Cline to communicate with LM Studio for local inference of coding agents.
 * How to use local coding agents to solve real-world software engineering tasks. 
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/supplemental/gaia-agents/README.md
+++ b/playbooks/supplemental/gaia-agents/README.md
@@ -23,9 +23,11 @@ In this playbook, you'll build a Hardware Advisor Agent that detects your system
 - Memory-based model sizing using the 70% rule
 - Building an interactive CLI for natural language hardware queries
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/supplemental/hermes-lemonade-server/README.md
+++ b/playbooks/supplemental/hermes-lemonade-server/README.md
@@ -27,9 +27,11 @@ By the end of this playbook you will be able to:
 
 ---
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/supplemental/lemonade-getting-started/README.md
+++ b/playbooks/supplemental/lemonade-getting-started/README.md
@@ -26,9 +26,11 @@ By the end of this playbook you will be able to:
 * **Run models on the AMD Neural Processing Unit (NPU)** using Hybrid and FLM execution modes on AMD Ryzen™ AI hardware.
 <!-- @device:end -->
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/supplemental/llama-factory-finetuning/README.md
+++ b/playbooks/supplemental/llama-factory-finetuning/README.md
@@ -43,9 +43,11 @@ This playbook teaches you how to fine-tune LLMs using LLaMA Factory on your loca
 - Duration: It will take about 60 minutes to run this playbook (depending on your model/dataset size and network speed).
 - View the [LLaMA Factory GitHub](https://github.com/hiyouga/LlamaFactory) for more information.
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/supplemental/ollama-getting-started/README.md
+++ b/playbooks/supplemental/ollama-getting-started/README.md
@@ -22,9 +22,11 @@ This playbook walks you through installing Ollama, pulling the GPT-OSS 20B model
 - Chat with models using the CLI
 - Query models programmatically through the REST API
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/supplemental/open-webui-chat/README.md
+++ b/playbooks/supplemental/open-webui-chat/README.md
@@ -75,9 +75,11 @@ Lemonade runs the models; Open WebUI is the interface you interact with. Use the
 
 ---
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/supplemental/openclaw-lemonade-server/README.md
+++ b/playbooks/supplemental/openclaw-lemonade-server/README.md
@@ -27,9 +27,11 @@ By the end of this playbook you will be able to:
 
 ---
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/supplemental/pytorch-finetuning/README.md
+++ b/playbooks/supplemental/pytorch-finetuning/README.md
@@ -56,9 +56,11 @@ This tutorial provides step-by-step examples for fine-tuning a large language mo
 - How to save and deploy your fine-tuned model
 - How to monitor training and debug common issues
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/supplemental/speech2speech-translation/README.md
+++ b/playbooks/supplemental/speech2speech-translation/README.md
@@ -27,9 +27,11 @@ This playbook will teach you how to run low-latency, expressive, and private spe
 - Conveys tone, emotion, and intent without awkward pauses
 - Enables global collaboration and faster decision-making
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates

--- a/playbooks/supplemental/unsloth-llms-finetuning/README.md
+++ b/playbooks/supplemental/unsloth-llms-finetuning/README.md
@@ -51,9 +51,11 @@ In this playbook, we use Unsloth together with **LoRA-based SFT**. That means th
 
 Unsloth also supports other training approaches, including QLoRA and reinforcement learning workflows. This playbook focuses on the simplest path first: a small LoRA fine-tuning example that users can run, understand, and extend.
 
+<!-- @device:halo_box,halo,stx,krk -->
 ## Setting the Memory Configuration
 
 <!-- @require:memory-config -->
+<!-- @device:end -->
 
 <!-- @device:halo_box -->
 ## Check for Software Updates


### PR DESCRIPTION
The 'memory config' header still shows even when dGPUs are toggled. This is incorrect behaviour as dGPUs don't have unified memory and no memory configuration to set. 

This PR simply adds the device flag to the header so that it doesn't show when dGPU is toggled.