### PR TITLE
Standardize container instructions on the docker command (podman-docker)

### DIFF
--- a/playbooks/core/n8n-automation-gpt-oss/README.md
+++ b/playbooks/core/n8n-automation-gpt-oss/README.md
@@ -229,7 +229,7 @@ n8n --version
 <!-- @os:end -->
 
 <!-- @os:linux -->
-We are now going to use Podman service to containerize our n8n installation.
+We are now going to use a container engine to containerize our n8n installation.
 
 Please download the following into a directory of your choice: [compose.yml](assets/compose.yml)
 

--- a/playbooks/core/n8n-automation-gpt-oss/README.md
+++ b/playbooks/core/n8n-automation-gpt-oss/README.md
@@ -235,7 +235,7 @@ Please download the following into a directory of your choice: [compose.yml](ass
 
 In that directory, run the following command:
 ```bash
-podman compose up -d
+docker compose up -d
 ```
 
 This should install n8n and write to a persistent storage.

--- a/playbooks/dependencies/podman.md
+++ b/playbooks/dependencies/podman.md
@@ -4,31 +4,35 @@ Copyright Advanced Micro Devices, Inc.
 SPDX-License-Identifier: MIT
 -->
 
-### Podman
+### Container Engine (Docker or Podman)
 
-Podman is containerization software for Linux.
+These steps use the `docker` command. It works whether you have Docker itself, or `podman-docker` (a wrapper that provides a `docker`-compatible command backed by the Podman engine).
 
+> **Already have Docker?** Use it as-is — you do not need to install anything below, and you should not install Podman alongside it. The `docker` commands in this playbook will work directly.
 
-**Step 1**: Install the core Podman engine and the standalone Compose V2 parsing plugin.
+If you don't have a container engine yet, install `podman-docker`. It pulls in the Podman engine automatically and adds the `docker` command that maps to it, so a single package gives you everything the playbook needs.
 
-```bash
-sudo apt update && sudo apt install -y podman docker-compose-plugin podman-compose
-```
-
-**Step 2**: Verify Podman and Compose
+**Step 1**: Install `podman-docker` (engine + `docker` wrapper) and the Compose provider.
 
 ```bash
-podman --version
-podman-compose --version
+sudo apt update && sudo apt install -y podman-docker podman-compose
 ```
 
-**Step 3**: Enable the system-wide Podman API socket so the Compose plugin can communicate with the container runtime.
+**Step 2**: Verify the `docker` command and Compose are available.
+
+```bash
+docker --version
+docker compose version
+```
+
+**Step 3**: Enable the system-wide Podman API socket so Compose can communicate with the container runtime.
 
 ```bash
 sudo systemctl enable --now podman.socket
 ```
-**Step 4**: Run a temporary test container to verify the engine can successfully pull and execute images.
+
+**Step 4**: Run a temporary test container to verify the engine can pull and execute images.
 
 ```bash
-sudo podman run --rm docker.io/library/hello-world
+docker run --rm docker.io/library/hello-world
 ```

--- a/playbooks/dependencies/registry.json
+++ b/playbooks/dependencies/registry.json
@@ -267,8 +267,8 @@
       "versionable": true
     },
     "podman": {
-      "name": "Podman",
-      "description": "Container management tool for running OCI containers",
+      "name": "Container Engine (Docker/Podman)",
+      "description": "Container engine for running OCI containers; use the docker command (Docker or podman-docker)",
       "category": "framework",
       "platforms": [
         "linux"

--- a/playbooks/supplemental/clustering-rccl/README.md
+++ b/playbooks/supplemental/clustering-rccl/README.md
@@ -121,7 +121,7 @@ This amount can be increased by changing the kernel's Translation Table Manager 
 
 > **Note**: Complete this step on both Machine 1 and Machine 2.
 
-Your Ryzen AI Halo ships with vLLM packaged inside a prebuilt container image, which you run using Podman, a free and open source container tool.
+Your Ryzen AI Halo ships with vLLM packaged inside a prebuilt container image, which you run using the `docker` command (backed by Docker or podman-docker).
 
 ### 1. Create the Model Download Directory
 
@@ -147,7 +147,7 @@ docker run -it --name vllm_cluster --replace --pull missing --network=host --dev
 
 vLLM uses Ray to orchestrate the cluster and RCCL to handle GPU-to-GPU communication across nodes. One machine acts as the **head node** (Machine 1), coordinating inference. The other joins as a **worker node** (Machine 2), contributing its GPU memory and compute.
 
-> **Note**: Ray is an optional dependency for vLLM and is only available from within the preconfigured Podman container.
+> **Note**: Ray is an optional dependency for vLLM and is only available from within the preconfigured container.
 
 At launch, vLLM shards the model across both nodes using tensor parallelism. Once loaded, inference proceeds as if running on a single accelerator.
 

--- a/playbooks/supplemental/clustering-rccl/README.md
+++ b/playbooks/supplemental/clustering-rccl/README.md
@@ -138,7 +138,7 @@ The command below launches the container and drops you into an interactive shell
 Start the container with:
 
 ```bash
-sudo podman run -it --name vllm_cluster --replace --pull missing --network=host --device /dev/kfd --device /dev/dri -v ~/.local/share/vLLM/models:/opt/vLLM/models --env HF_HOME=/opt/vLLM/models --entrypoint="bin/bash" --shm-size=64g --pids-limit=-1 -e NCCL_SOCKET_IFNAME=<IFNAME> -e GLOO_SOCKET_IFNAME=<IFNAME> oci-registry.ryai.dev/ryai-vllm:latest
+docker run -it --name vllm_cluster --replace --pull missing --network=host --device /dev/kfd --device /dev/dri -v ~/.local/share/vLLM/models:/opt/vLLM/models --env HF_HOME=/opt/vLLM/models --entrypoint="bin/bash" --shm-size=64g --pids-limit=-1 -e NCCL_SOCKET_IFNAME=<IFNAME> -e GLOO_SOCKET_IFNAME=<IFNAME> oci-registry.ryai.dev/ryai-vllm:latest
 ```
 
 > **Note**: Replace `<IFNAME>` with the output interface name from [1. Determine Network Interfaces](#1-determine-network-interfaces)

--- a/playbooks/supplemental/deepseek-v4-flash-ds4/README.md
+++ b/playbooks/supplemental/deepseek-v4-flash-ds4/README.md
@@ -38,21 +38,21 @@ This tutorial shows how to use `ds4-cockpit`, a terminal UI, to set up ds4, down
 >
 > **Note:** Try setting the **GPU shared-memory pool** to **110 GB** as a starting point. If you hit out-of-memory errors, raise the shared-memory pool or lower the context size.
 
-ds4-cockpit uses container toolboxes to run the ds4 engine. Install `podman`, `distrobox`, and `pipx`:
+ds4-cockpit uses container toolboxes to run the ds4 engine. Install `podman-docker`, `distrobox`, and `pipx`:
 
 ```bash
 sudo apt update
-sudo apt install -y podman distrobox pipx
+sudo apt install -y podman-docker distrobox pipx
 ```
 
 <!-- @test:id=ds4-prereqs-linux timeout=60 hidden=True -->
 ```bash
 set -euo pipefail
 export PATH="$HOME/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
-podman --version
+docker --version
 distrobox version 2>/dev/null || distrobox --version
 pipx --version
-echo "OK: podman, distrobox, and pipx are installed"
+echo "OK: docker, distrobox, and pipx are installed"
 ```
 <!-- @test:end -->
 
@@ -107,7 +107,7 @@ set -euo pipefail
 export PATH="$HOME/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
 
 # The toolbox version changes over time, so match the image family, not a fixed tag.
-if ! podman images --format '{{.Repository}}:{{.Tag}}' | grep -i 'strix-halo-ds4-toolbox'; then
+if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep -i 'strix-halo-ds4-toolbox'; then
   echo "No strix-halo-ds4-toolbox image found. Create the toolbox in ds4-cockpit (Interactive Toolboxes tab) first."
   exit 1
 fi
@@ -200,7 +200,7 @@ fi
 model_name="$(basename "$model_file")"
 
 # Pick the toolbox image (version-agnostic).
-image="$(podman images --format '{{.Repository}}:{{.Tag}}' | grep -i 'strix-halo-ds4-toolbox' | head -1)"
+image="$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -i 'strix-halo-ds4-toolbox' | head -1)"
 if [ -z "$image" ]; then
   echo "No strix-halo-ds4-toolbox image found. Create the toolbox in ds4-cockpit first."
   exit 1
@@ -208,14 +208,14 @@ fi
 
 # Always stop/remove the server on exit so it never holds GPU memory afterwards.
 cleanup() {
-  podman stop -t 10 "$CONTAINER" >/dev/null 2>&1 || true
-  podman rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  docker stop -t 10 "$CONTAINER" >/dev/null 2>&1 || true
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
 # Remove any stale instance, then start ds4-server detached (same flags ds4-cockpit uses, with -d instead of -it).
-podman rm -f "$CONTAINER" >/dev/null 2>&1 || true
-podman run -d --name "$CONTAINER" \
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+docker run -d --name "$CONTAINER" \
   --device /dev/dri --device /dev/kfd \
   --group-add keep-groups \
   --security-opt seccomp=unconfined \
@@ -236,9 +236,9 @@ for i in $(seq 1 240); do
     up=true
     break
   fi
-  if ! podman inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q true; then
+  if ! docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q true; then
     echo "ds4-server container exited during startup:"
-    podman logs "$CONTAINER" 2>&1 | tail -40 || true
+    docker logs "$CONTAINER" 2>&1 | tail -40 || true
     exit 1
   fi
   sleep 2
@@ -246,7 +246,7 @@ done
 
 if [ "$up" != "true" ]; then
   echo "ds4 server did not become ready on http://127.0.0.1:8000"
-  podman logs "$CONTAINER" 2>&1 | tail -40 || true
+  docker logs "$CONTAINER" 2>&1 | tail -40 || true
   exit 1
 fi
 echo "OK: ds4 server is responding on :8000"

--- a/playbooks/supplemental/hermes-lemonade-server/README.md
+++ b/playbooks/supplemental/hermes-lemonade-server/README.md
@@ -43,9 +43,9 @@ By the end of this playbook you will be able to:
 - A PC running **Ubuntu 24.04+** or a compatible Debian-based Linux distribution with `apt-get`
 - At least **12 GB of RAM** (64 GB+ recommended for larger models)
 - **~10–30 GB of free disk space** for model weights
-- [Podman](https://podman.io/docs/installation) (Optional, for sandboxing Hermes Agent)
-  ```bash 
-  sudo apt-get install -y podman`
+- A container engine (Optional, for sandboxing Hermes Agent). If you don't already have Docker, install `podman-docker`, which provides the `docker` command:
+  ```bash
+  sudo apt-get install -y podman-docker
   ```
 <!-- @os:end -->
 
@@ -53,14 +53,14 @@ By the end of this playbook you will be able to:
 - A PC running **Windows 10/11**
 - At least **12 GB of RAM** (64 GB+ recommended for larger models)
 - **~10–30 GB of free disk space** for model weights
-- Podman (Optional, for sandboxing Hermes Agent). Install inside WSL:
-  ```bash 
-  sudo apt-get install -y podman
+- A container engine (Optional, for sandboxing Hermes Agent). If you don't already have Docker, install `podman-docker` inside WSL, which provides the `docker` command:
+  ```bash
+  sudo apt-get install -y podman-docker
   ```
 <!-- @os:end -->
 
 <!-- @device:halo_box -->
-> Podman is pre-installed on Halo Box and no setup is required
+> A container engine is pre-installed on Halo Box and no setup is required
 <!-- @device:end -->
 
 <!-- @require:lemonade -->
@@ -679,7 +679,7 @@ Build a lightweight sandbox image:
 
 <!-- @os:linux -->
 ```bash
-podman build -t hermes-sandbox:bookworm-slim - <<'DOCKERFILE'
+docker build -t hermes-sandbox:bookworm-slim - <<'DOCKERFILE'
 FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -696,9 +696,9 @@ DOCKERFILE
 ```bash
 set -euo pipefail
 
-podman version
+docker version
 
-podman build -t hermes-sandbox:bookworm-slim - <<'DOCKERFILE'
+docker build -t hermes-sandbox:bookworm-slim - <<'DOCKERFILE'
 FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -710,7 +710,7 @@ WORKDIR /home/sandbox
 CMD ["sleep", "infinity"]
 DOCKERFILE
 
-podman image inspect hermes-sandbox:bookworm-slim >/dev/null
+docker image inspect hermes-sandbox:bookworm-slim >/dev/null
 
 echo "OK: Hermes sandbox Podman image is available"
 ```
@@ -727,7 +727,7 @@ wsl -d Ubuntu-24.04
 Then, build a lightweight sandbox image:
 
 ```bash
-podman build -t hermes-sandbox:bookworm-slim - <<'DOCKERFILE'
+docker build -t hermes-sandbox:bookworm-slim - <<'DOCKERFILE'
 FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -747,9 +747,9 @@ $ErrorActionPreference = "Stop"
 $script = @'
 set -euo pipefail
 
-podman version
+docker version
 
-podman build -t hermes-sandbox:bookworm-slim - <<'DOCKERFILE'
+docker build -t hermes-sandbox:bookworm-slim - <<'DOCKERFILE'
 FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -761,7 +761,7 @@ WORKDIR /home/sandbox
 CMD ["sleep", "infinity"]
 DOCKERFILE
 
-podman image inspect hermes-sandbox:bookworm-slim >/dev/null
+docker image inspect hermes-sandbox:bookworm-slim >/dev/null
 
 echo "OK: Hermes sandbox Podman image is available inside WSL"
 '@
@@ -790,7 +790,7 @@ finally {
 Then configure Hermes to use Podman as the container runtime and set the terminal backend:
 
 ```bash
-echo "HERMES_DOCKER_BINARY=/usr/bin/podman" >> ~/.hermes/.env
+echo "HERMES_DOCKER_BINARY=/usr/bin/docker" >> ~/.hermes/.env
 
 cat >> ~/.hermes/config.yaml <<'EOF'
 terminal:
@@ -800,7 +800,7 @@ EOF
 ```
 
 > The `terminal.backend` is still `docker`.
-> `HERMES_DOCKER_BINARY` is what tells Hermes to use Podman as the runtime instead.
+> `HERMES_DOCKER_BINARY` points Hermes at the `docker` command (Docker or podman-docker).
 
 <!-- @os:linux -->
 <!-- @test:id=hermes-sandbox-config-linux timeout=120 hidden=True -->
@@ -815,14 +815,14 @@ if [ ! -f "$config" ]; then
 fi
 
 # The sandbox image must exist before Hermes can use it as the terminal backend.
-podman image inspect hermes-sandbox:bookworm-slim >/dev/null
+docker image inspect hermes-sandbox:bookworm-slim >/dev/null
 
 # Point Hermes at Podman as the container runtime (idempotent: drop any prior line first).
 mkdir -p "$HOME/.hermes"
 touch "$HOME/.hermes/.env"
 grep -v '^HERMES_DOCKER_BINARY=' "$HOME/.hermes/.env" > "$HOME/.hermes/.env.tmp" || true
 mv "$HOME/.hermes/.env.tmp" "$HOME/.hermes/.env"
-echo "HERMES_DOCKER_BINARY=/usr/bin/podman" >> "$HOME/.hermes/.env"
+echo "HERMES_DOCKER_BINARY=/usr/bin/docker" >> "$HOME/.hermes/.env"
 
 # Append the terminal backend block (config.yaml is rewritten fresh by the model-config test each run, so this appends exactly once per run).
 cat >> "$config" <<'EOF'
@@ -831,7 +831,7 @@ terminal:
   docker_image: hermes-sandbox:bookworm-slim
 EOF
 
-grep -q "HERMES_DOCKER_BINARY=/usr/bin/podman" "$HOME/.hermes/.env"
+grep -q "HERMES_DOCKER_BINARY=/usr/bin/docker" "$HOME/.hermes/.env"
 grep -q "backend: docker" "$config"
 grep -q "docker_image: hermes-sandbox:bookworm-slim" "$config"
 
@@ -855,13 +855,13 @@ if [ ! -f "$config" ]; then
   exit 1
 fi
 
-podman image inspect hermes-sandbox:bookworm-slim >/dev/null
+docker image inspect hermes-sandbox:bookworm-slim >/dev/null
 
 mkdir -p "$HOME/.hermes"
 touch "$HOME/.hermes/.env"
 grep -v '^HERMES_DOCKER_BINARY=' "$HOME/.hermes/.env" > "$HOME/.hermes/.env.tmp" || true
 mv "$HOME/.hermes/.env.tmp" "$HOME/.hermes/.env"
-echo "HERMES_DOCKER_BINARY=/usr/bin/podman" >> "$HOME/.hermes/.env"
+echo "HERMES_DOCKER_BINARY=/usr/bin/docker" >> "$HOME/.hermes/.env"
 
 cat >> "$config" <<'EOF'
 terminal:
@@ -869,7 +869,7 @@ terminal:
   docker_image: hermes-sandbox:bookworm-slim
 EOF
 
-grep -q "HERMES_DOCKER_BINARY=/usr/bin/podman" "$HOME/.hermes/.env"
+grep -q "HERMES_DOCKER_BINARY=/usr/bin/docker" "$HOME/.hermes/.env"
 grep -q "backend: docker" "$config"
 grep -q "docker_image: hermes-sandbox:bookworm-slim" "$config"
 
@@ -940,13 +940,13 @@ RemainAfterExit=yes
 WorkingDirectory=${HOME}/firecrawl
 
 # Optional: Validate config before starting
-ExecStartPre=/usr/bin/podman -f hermes-compose.yaml config --quiet
+ExecStartPre=/usr/bin/docker compose -f hermes-compose.yaml config --quiet
 
 # Start containers in detached mode
-ExecStart=/usr/bin/podman compose -f hermes-compose.yaml up -d --remove-orphans
+ExecStart=/usr/bin/docker compose -f hermes-compose.yaml up -d --remove-orphans
 
 # Stop containers when the service stops
-ExecStop=/usr/bin/podman compose -f hermes-compose.yaml down
+ExecStop=/usr/bin/docker compose -f hermes-compose.yaml down
 
 [Install]
 WantedBy=default.target
@@ -1006,7 +1006,7 @@ BULL_AUTH_KEY=CHANGEME
 
 Before moving on, make sure you have pulled the latest Hermes Docker image:
 ```bash
-podman pull docker.io/nousresearch/hermes-agent:latest
+docker pull docker.io/nousresearch/hermes-agent:latest
 ```
 Once that is done, download the Hermes Compose file [hermes-compose.yaml](assets/hermes-compose.yaml) and place it in the root `/firecrawl` directory:
 
@@ -1018,7 +1018,7 @@ Once that is done, download the Hermes Compose file [hermes-compose.yaml](assets
 
 Before handing control over to `systemd`, validate that everything works correctly by running the stack manually:
 ```bash
-podman compose -f hermes-compose.yaml up -d
+docker compose -f hermes-compose.yaml up -d
 ```
 If everything is configured correctly, you should see the Hermes container come up and your command line output should look similar to this:
 <p align="center">
@@ -1027,7 +1027,7 @@ If everything is configured correctly, you should see the Hermes container come 
 
 Once verified, bring the stack back down before proceeding:
 ```bash
-podman compose -f hermes-compose.yaml down
+docker compose -f hermes-compose.yaml down
 ```
 Now that everything is validated, start the service through `systemd`:
 ```bash

--- a/playbooks/supplemental/open-webui-chat/README.md
+++ b/playbooks/supplemental/open-webui-chat/README.md
@@ -87,7 +87,7 @@ Lemonade runs the models; Open WebUI is the interface you interact with. Use the
 
 ## One-Time Setup
 
-This playbook needs Lemonade running as the backend and, on Linux, a container engine (Podman) to run Open WebUI. Set these up before installing Open WebUI.
+This playbook needs Lemonade running as the backend and, on Linux, a container engine (Docker or podman-docker) to run Open WebUI. Set these up before installing Open WebUI.
 
 <!-- @os:windows -->
 <!-- @device:halo_box,halo,stx,krk -->
@@ -101,10 +101,10 @@ This playbook needs Lemonade running as the backend and, on Linux, a container e
 
 <!-- @os:linux -->
 <!-- @device:halo_box,halo,stx,krk -->
-<!-- @require:lemonade,docker -->
+<!-- @require:lemonade,podman -->
 <!-- @device:end -->
 <!-- @device:rx7900xt,rx9070xt,r9700 -->
-<!-- @require:driver,lemonade,docker -->
+<!-- @require:driver,lemonade,podman -->
 <!-- @device:end -->
 <!-- @device:halo,stx,krk,rx7900xt,rx9070xt,r9700 -->
 ---
@@ -566,7 +566,7 @@ Write-Host "OK: open-webui CLI is available"
 <!-- @os:end -->
 
 <!-- @os:linux -->
-We are now going to use Podman service to containerize our Open WebUI installation.
+We are now going to use a container engine to containerize our Open WebUI installation.
 
 Please download the following into a directory of your choice: [compose.yml](assets/compose.yml)
 
@@ -593,7 +593,7 @@ if [ ! -f compose.yml ]; then
   exit 1
 fi
 
-echo "OK: Podman, Podman Compose, and compose.yml are available"
+echo "OK: container engine, Compose, and compose.yml are available"
 ```
 <!-- @test:end -->
 
@@ -632,7 +632,7 @@ if "open_webui_data:/app/backend/data" not in volumes:
 if "open_webui_data" not in data.get("volumes", {}):
     raise SystemExit("Expected top-level open_webui_data volume")
 
-print("OK: compose.yml matches the Open WebUI Podman setup")
+print("OK: compose.yml matches the Open WebUI container setup")
 PY
 
 docker compose -f compose.yml config >/dev/null

--- a/playbooks/supplemental/open-webui-chat/README.md
+++ b/playbooks/supplemental/open-webui-chat/README.md
@@ -101,10 +101,10 @@ This playbook needs Lemonade running as the backend and, on Linux, a container e
 
 <!-- @os:linux -->
 <!-- @device:halo_box,halo,stx,krk -->
-<!-- @require:lemonade,podman -->
+<!-- @require:lemonade,docker -->
 <!-- @device:end -->
 <!-- @device:rx7900xt,rx9070xt,r9700 -->
-<!-- @require:driver,lemonade,podman -->
+<!-- @require:driver,lemonade,docker -->
 <!-- @device:end -->
 <!-- @device:halo,stx,krk,rx7900xt,rx9070xt,r9700 -->
 ---
@@ -573,7 +573,7 @@ Please download the following into a directory of your choice: [compose.yml](ass
 In that directory, run the following command:
 
 ```bash
-podman compose up -d
+docker compose up -d
 ```
 
 This pulls the Open WebUI image and writes to persistent storage.
@@ -584,12 +584,9 @@ Launch Open WebUI by typing `localhost:8080` into your browser address bar.
 ```bash
 set -euo pipefail
 
-export PODMAN_COMPOSE_PROVIDER="$(command -v podman-compose)"
-export PODMAN_COMPOSE_WARNING_LOGS=false
-
-podman --version
-podman compose version
-podman info >/dev/null
+docker --version
+docker compose version
+docker info >/dev/null
 
 if [ ! -f compose.yml ]; then
   echo "compose.yml not found in current working directory (playbooks/supplemental/open-webui-chat/assets)"
@@ -638,9 +635,9 @@ if "open_webui_data" not in data.get("volumes", {}):
 print("OK: compose.yml matches the Open WebUI Podman setup")
 PY
 
-podman compose -f compose.yml config >/dev/null
+docker compose -f compose.yml config >/dev/null
 
-echo "OK: podman compose can parse compose.yml"
+echo "OK: docker compose can parse compose.yml"
 ```
 <!-- @test:end -->
 <!-- @os:end -->
@@ -668,7 +665,7 @@ open-webui serve
 <!-- @os:end -->
 
 <!-- @os:linux -->
-> The container runs in the background. From the directory containing `compose.yml`, manage it with `podman compose down` (stop) and `podman compose up -d` (start). Your accounts and settings persist in the `open_webui_data` volume.
+> The container runs in the background. From the directory containing `compose.yml`, manage it with `docker compose down` (stop) and `docker compose up -d` (start). Your accounts and settings persist in the `open_webui_data` volume.
 <!-- @os:end -->
 
 
@@ -716,18 +713,15 @@ finally {
 ```bash
 set -euo pipefail
 
-export PODMAN_COMPOSE_PROVIDER="$(command -v podman-compose)"
-export PODMAN_COMPOSE_WARNING_LOGS=false
-
 cleanup() {
-  podman compose -f compose.yml down >/dev/null 2>&1 || true
+  docker compose -f compose.yml down >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
 # Clean up a stale container from a previous failed run.
-podman rm -f open-webui >/dev/null 2>&1 || true
+docker rm -f open-webui >/dev/null 2>&1 || true
 
-podman compose -f compose.yml up -d
+docker compose -f compose.yml up -d
 
 health=""
 for i in $(seq 1 180); do
@@ -741,16 +735,16 @@ done
 if [ -z "$health" ]; then
   echo "Open WebUI did not become ready on http://127.0.0.1:8080/health"
   echo "Container status:"
-  podman ps -a || true
+  docker ps -a || true
   echo "Open WebUI logs:"
-  podman logs --tail 200 open-webui || true
+  docker logs --tail 200 open-webui || true
   exit 1
 fi
 
 echo "OK: Open WebUI container is responding on /health"
 
 # Verify that the Open WebUI container can reach Lemonade through host networking.
-podman exec open-webui sh -lc 'python -c "import json, urllib.request; data=json.load(urllib.request.urlopen(\"http://127.0.0.1:13305/api/v1/models\", timeout=10)); assert \"data\" in data; print(\"OK: Open WebUI container can reach Lemonade models endpoint\")"'
+docker exec open-webui sh -lc 'python -c "import json, urllib.request; data=json.load(urllib.request.urlopen(\"http://127.0.0.1:13305/api/v1/models\", timeout=10)); assert \"data\" in data; print(\"OK: Open WebUI container can reach Lemonade models endpoint\")"'
 ```
 <!-- @test:end --> 
 <!-- @os:end --> 

--- a/playbooks/supplemental/openclaw-lemonade-server/README.md
+++ b/playbooks/supplemental/openclaw-lemonade-server/README.md
@@ -958,19 +958,19 @@ RemainAfterExit=yes
 WorkingDirectory=%h/firecrawl
 
 # Optional: Validate config before starting
-ExecStartPre=/usr/bin/podman compose -f openclaw-compose.yaml config --quiet
+ExecStartPre=/usr/bin/docker compose -f openclaw-compose.yaml config --quiet
 
 # Generate token and write to .env file
 ExecStartPre=/bin/bash -c 'chmod 644 %h/firecrawl/.env && echo "OPENCLAW_GATEWAY_TOKEN=$(openssl rand -hex 32)" > %h/firecrawl/.env'
 
 # Step 1: Start containers in detached mode
-ExecStart=/usr/bin/podman compose -f openclaw-compose.yaml up -d --remove-orphans
+ExecStart=/usr/bin/docker compose -f openclaw-compose.yaml up -d --remove-orphans
 
 # Step 2: Wait for container to be healthy/ready
 ExecStartPost=/bin/sleep 5
 
 # Step 3: Run onboarding inside container in detached mode
-ExecStartPost=/usr/bin/podman exec -d openclaw_gateway /bin/bash -c "openclaw onboard \
+ExecStartPost=/usr/bin/docker exec -d openclaw_gateway /bin/bash -c "openclaw onboard \
     --non-interactive \
     --accept-risk \
     --mode local \
@@ -979,7 +979,7 @@ ExecStartPost=/usr/bin/podman exec -d openclaw_gateway /bin/bash -c "openclaw on
     --gateway-token "$OPENCLAW_GATEWAY_TOKEN" "
 
 # Stop containers when the service stops
-ExecStop=/usr/bin/podman compose -f openclaw-compose.yaml down
+ExecStop=/usr/bin/docker compose -f openclaw-compose.yaml down
 
 [Install]
 WantedBy=default.target
@@ -1017,7 +1017,7 @@ HOST=0.0.0.0
 
 Before moving on, make sure you have pulled the latest OpenClaw Docker image:
 ```bash
-podman pull ghcr.io/openclaw/openclaw:latest
+docker pull ghcr.io/openclaw/openclaw:latest
 ```
 Once that is done, download the OpenClaw Compose file [openclaw-compose.yaml](assets/openclaw-compose.yaml) and place it in the root `/firecrawl` directory:
 
@@ -1029,7 +1029,7 @@ Once that is done, download the OpenClaw Compose file [openclaw-compose.yaml](as
 
 Before handing control over to `systemd`, validate that everything works correctly by running the stack manually:
 ```bash
-podman compose -f openclaw-compose.yaml up -d
+docker compose -f openclaw-compose.yaml up -d
 ```
 If everything is configured correctly, you should see the OpenClaw container come up and your command line output should look similar to this:
 <p align="center">
@@ -1038,7 +1038,7 @@ If everything is configured correctly, you should see the OpenClaw container com
 
 Once verified, bring the stack back down before proceeding:
 ```bash
-podman compose -f openclaw-compose.yaml down
+docker compose -f openclaw-compose.yaml down
 ```
 Before starting the service, you must ensure the correct ownership and permissions are set on the `firecrawl` directory and its `.env` file. 
 This is essential for the service to write your credentials at startup.


### PR DESCRIPTION
Playbooks previously mixed podman and docker commands, which caused friction for users who had one engine but not the other (surfaced by a user hitting podman-specific steps in the Hermes playbook).

Approach: all container instructions now use the docker command, which works with either real Docker or podman-docker (a wrapper that provides a docker-compatible CLI backed by the Podman engine, available in the Ubuntu repos). This means users need one of: Docker (if already installed), or podman-docker (which pulls in the Podman engine automatically). podman-docker is already preinstalled on HaloBox Linux.

Changes:
- dependencies/podman.md (shared container dependency): install simplified to sudo apt install -y podman-docker podman-compose; verify/run steps use docker / docker compose; added guidance that if you already have Docker you should use it and not install podman.
- User-facing instructions converted podman → docker in: n8n, open-webui, clustering-rccl, deepseek (install → podman-docker).
- CI test blocks updated to match the READMEs exactly (docker compose, docker exec/ps/logs, etc.); removed the now-unneeded PODMAN_COMPOSE_PROVIDER shim.
- Hermes & openclaw: converted HERMES_DOCKER_BINARY and systemd ExecStart* to /usr/bin/docker, and docker build/pull/compose/exec throughout. Windows paths run inside WSL, so podman-docker + docker apply there too. Also fixed two pre-existing bugs in Hermes along the way (stray backtick in the install command, and a malformed ExecStartPre missing the compose subcommand).
- Retitled the registry entry from "Podman" to "Container Engine (Docker/Podman)".

Intentionally unchanged: 
- podman.socket/podman.service systemd unit names, the podman-docker/podman-compose package names, the @require:podman dependency id, and docker.io/... registry paths.

Requires: 
- CI runners (and non-HaloBox target machines) to have podman-docker installed so docker / /usr/bin/docker resolve.

Known follow-up (not in this PR): 
- OpenClaw's prerequisites still reference Docker Desktop for its optional sandbox — left as-is since it's optional and functional; can be reframed to podman-docker later.