### PR TITLE
pytorch-finetuning, speech2speech: bump transformers 4.57.1 -> 5.10.1

### DIFF
--- a/playbooks/supplemental/pytorch-finetuning/README.md
+++ b/playbooks/supplemental/pytorch-finetuning/README.md
@@ -465,16 +465,18 @@ required = [
     "config.json",
     "tokenizer_config.json",
     "tokenizer.json",
-    "model.safetensors.index.json",
 ]
 missing = [f for f in required if not os.path.exists(os.path.join(out_dir, f))]
 if missing:
     print(f"FAIL: Missing required files: {missing}")
     sys.exit(1)
 
+# Weights may be saved as a single model.safetensors or, when the model
+# exceeds max_shard_size, as model-*.safetensors shards plus an index.
+single = os.path.exists(os.path.join(out_dir, "model.safetensors"))
 shards = glob.glob(os.path.join(out_dir, "model-*.safetensors"))
-if not shards:
-    print("FAIL: No sharded model safetensors files found")
+if not single and not shards:
+    print("FAIL: No model safetensors weights found")
     sys.exit(1)
 
 print(f"PASS: Full fine-tuned model output looks correct: {out_dir}")

--- a/playbooks/supplemental/pytorch-finetuning/README.md
+++ b/playbooks/supplemental/pytorch-finetuning/README.md
@@ -135,7 +135,7 @@ finetune-venv\Scripts\activate
 <!-- @os:linux -->
 <!-- @test:id=install-deps timeout=300 setup=activate-venv -->
 ```bash
-pip install transformers==4.57.1 safetensors==0.6.2 accelerate peft trl bitsandbytes "fsspec[http]>=2023.1.0,<=2025.9.0"
+pip install transformers==5.10.1 safetensors==0.6.2 accelerate peft trl bitsandbytes "fsspec[http]>=2023.1.0,<=2025.9.0"
 ```
 <!-- @test:end -->
 <!-- @os:end -->
@@ -144,7 +144,7 @@ pip install transformers==4.57.1 safetensors==0.6.2 accelerate peft trl bitsandb
 **Windows:** Only core packages are tested and supported here. **bitsandbytes is not well supported on Windows**, so the Windows install omits it; use LoRA or full fine-tuning on Windows (QLoRA requires bitsandbytes and is intended for Linux).
 <!-- @test:id=install-deps timeout=300 setup=activate-venv -->
 ```bash
-pip install transformers==4.57.1 safetensors==0.6.2 datasets==4.2.0 accelerate peft trl "fsspec[http]>=2023.1.0,<=2025.9.0"
+pip install transformers==5.10.1 safetensors==0.6.2 datasets==4.2.0 accelerate peft trl "fsspec[http]>=2023.1.0,<=2025.9.0"
 ```
 <!-- @test:end -->
 <!-- @os:end -->

--- a/playbooks/supplemental/pytorch-finetuning/assets/train_full_finetuning.py
+++ b/playbooks/supplemental/pytorch-finetuning/assets/train_full_finetuning.py
@@ -171,7 +171,6 @@ args = SFTConfig(
     logging_steps=5,
     save_strategy="epoch",
     eval_strategy="epoch",
-    save_safetensors=True,
     save_total_limit=1,                # Keep only last checkpoint to save disk space
     
     # Other

--- a/playbooks/supplemental/pytorch-finetuning/assets/train_lora.py
+++ b/playbooks/supplemental/pytorch-finetuning/assets/train_lora.py
@@ -230,7 +230,6 @@ args = SFTConfig(
     logging_steps=5,
     save_strategy="epoch",
     eval_strategy="epoch",
-    save_safetensors=True,
     save_total_limit=2,
     
     # Other

--- a/playbooks/supplemental/pytorch-finetuning/assets/train_qlora.py
+++ b/playbooks/supplemental/pytorch-finetuning/assets/train_qlora.py
@@ -254,7 +254,6 @@ args = SFTConfig(
     logging_steps=5,
     save_strategy="epoch",
     eval_strategy="epoch",
-    save_safetensors=True,
     save_total_limit=2,
     
     # Other

--- a/playbooks/supplemental/speech2speech-translation/README.md
+++ b/playbooks/supplemental/speech2speech-translation/README.md
@@ -127,7 +127,7 @@ s2st-env\Scripts\activate
 Install m4t dependencies using pip:
 <!-- @test:id=install-deps timeout=300 setup=activate-venv -->
 ```bash
-pip install transformers==4.57.1 safetensors==0.6.2 tiktoken==0.9.0 accelerate soundfile==0.13.1 sentencepiece protobuf gradio scipy==1.15.3 
+pip install transformers==5.10.1 safetensors==0.6.2 tiktoken==0.9.0 accelerate soundfile==0.13.1 sentencepiece protobuf gradio scipy==1.15.3 
 ```
 <!-- @test:end -->
 


### PR DESCRIPTION
Matches the transformers 5.10.1 pin already adopted in pytorch-rocm-llms (#659). Closes #270. Unpinning the remaining pinned examples can be explored as a follow-up.