### PR TITLE
llama-factory: add GPU-visibility guard after pytorch install

### DIFF
--- a/playbooks/supplemental/llama-factory-finetuning/README.md
+++ b/playbooks/supplemental/llama-factory-finetuning/README.md
@@ -134,7 +134,23 @@ llamafactory-env\Scripts\activate
 ### Installing Basic Dependencies
 
 <!-- @require:pytorch,driver -->
- 
+
+<!-- @test:id=verify-torch-env timeout=300 hidden=True setup=activate-venv -->
+```python
+import sys
+import torch
+
+print(f"Python executable: {sys.executable}")
+print(f"PyTorch version: {torch.__version__}")
+print(f"torch.cuda.is_available(): {torch.cuda.is_available()}")
+
+if not torch.cuda.is_available():
+    raise SystemExit("FAIL: ROCm-enabled PyTorch is not visible in this venv")
+
+print("PASS: ROCm-enabled PyTorch is visible")
+```
+<!-- @test:end -->
+
 ### Installing Additional Dependencies
 
 > **Note**: Ensure Python version is 3.11, 3.12, or 3.13


### PR DESCRIPTION
Adds a `verify-torch-env` check after `@require:pytorch,driver`, byte-for-byte identical to the [unsloth-llms-finetuning block](https://github.com/amd/playbooks/blob/80faf7c0c7100f0de99bbb523c85956511218611/playbooks/supplemental/unsloth-llms-finetuning/README.md#L133-L147) and matching the `torch.cuda.is_available()` check in `supplemental/pytorch-finetuning`. llama-factory had no GPU check, so a mis-provisioned environment silently offloads training to CPU. Refs #242.