### PR TITLE
orchestrai: schedule hermes-lemonade-server on the 128 GB Halo batch

### DIFF
--- a/.github/orchestrai-config.yml
+++ b/.github/orchestrai-config.yml
@@ -96,6 +96,12 @@ extra_tags: {}
 # 128 GB tag for the Halo run. openclaw-lemonade-server is the same case: a fixed
 # Qwen3.6-35B-A3B (MoE, 3B active) that the legacy workflow schedules and runs on
 # every device via lemonade offload, so it also gets the 128 GB tag on Halo only.
+# hermes-lemonade-server pins the SAME Qwen3.6-35B-A3B at the same 262144 ctx and
+# belongs in the same bucket — it was simply missed. Without the tag it stayed in
+# the ordinary 64 GB Halo batch and never finished: Jenkins #40973 failed no
+# assertion, it just held its session until the 90-minute per-playbook ceiling and
+# was marked timed out, while openclaw passed on the 128 GB batch the same night.
+# The two are already treated as a pair in skip_playbook_devices below.
 device_extra_tags:
   unsloth-llms-finetuning:
     halo:     ["ram_128gb"]
@@ -117,6 +123,9 @@ device_extra_tags:
     halo:     ["ram_128gb"]
     halo_box: ["ram_128gb"]
   openclaw-lemonade-server:
+    halo:     ["ram_128gb"]
+    halo_box: ["ram_128gb"]
+  hermes-lemonade-server:
     halo:     ["ram_128gb"]
     halo_box: ["ram_128gb"]
 


### PR DESCRIPTION
## The failure

`hermes-lemonade-server` on Halo  **failed no assertion**. Its session stayed active until the pipeline's 90-minute per-playbook ceiling (`max_test_case_duration: 90`) and was marked timed out.

It pins `Qwen3.6-35B-A3B-GGUF` at a 262,144-token context — the same model and context as `openclaw-lemonade-server`, which **passed the same night**. The only variable that differed was the RAM class of the machine each landed on:

| | `device_extra_tags` entry | Halo batch | Result |
|---|---|---|---|
| `openclaw-lemonade-server` | `ram_128gb` | 128 GB | pass |
| `hermes-lemonade-server` | **none** | ordinary 64 GB | timed out |

The two are already treated as a pair in `skip_playbook_devices` (both skipped on 32 GB stx, for this exact model), so the missing `device_extra_tags` entry was an oversight rather than a decision.

## The change

Nine lines in `.github/orchestrai-config.yml`: the `ram_128gb` entry for `hermes-lemonade-server`, plus a comment recording why.

## Verified

Ran `orchestrai_matrix.py` over every `playbook.json` in the repo, before and after:

```
before                            after
linux/halo             (11)       linux/halo             (10)
linux/halo+ram_128gb    (7)       linux/halo+ram_128gb    (8)
windows/halo           (10)       windows/halo            (9)
windows/halo+ram_128gb  (7)       windows/halo+ram_128gb  (8)
```

Hermes' halo entries move into `+ram_128gb` on both platforms. Everything else is untouched:

- `rx7900xt` / `rx9070xt` / `r9700` keep **no** extra tag — `tags_for()` falls back to the empty `extra_tags` entry, so they are *not* dropped by `extra_tag_devices` (the same pattern the surrounding playbooks rely on).
- `stx` stays skipped via `skip_playbook_devices`.

Note the 128 GB batch grows by one while the plain Halo batch shrinks by one, so against `max_duration: 240` this **rebalances** rather than lengthens the critical batch.

## If it still times out

The scheduling gap is the clear first cause, but it may not be the only one. Both playbooks prime the model via the `model.lemonade.qwen3.6-35b` dependency from the Artifactory mirror specifically to avoid a "flaky ~22 GB live pull" — and that dependency **falls back to a live pull if the mirror is unreachable**. A ~22 GB live pull inside a 90-minute ceiling is its own timeout. If a rerun on the 128 GB batch still times out, check whether the model prime actually hit the mirror before touching `max_test_case_duration`.

