### PR TITLE
Add Collect Runner Specs workflow for full fleet hardware inventory

### DIFF
--- a/.github/workflows/collect-runner-specs.yml
+++ b/.github/workflows/collect-runner-specs.yml
@@ -1,0 +1,146 @@
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+name: Collect Runner Specs
+
+# One-off / on-demand hardware inventory of the self-hosted fleet.
+#
+# Fans out over every machine in .github/runners.json (via select_runners.py,
+# the same single-source-of-truth used by Runner Heartbeat) and dumps CPU,
+# memory, and GPU/VRAM info per runner as an artifact. Read-only: it only
+# queries hardware, never changes anything.
+#
+# Run it from the Actions tab (workflow_dispatch). Download the
+# "runner-specs-<name>" artifacts afterwards, or read the combined summary in
+# the "Combine specs" job's step summary.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: write   # upload artifacts
+  contents: read   # checkout to run select_runners.py
+
+jobs:
+  list-runners:
+    name: List runners
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.list.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build runner matrix from runners.json
+        id: list
+        run: |
+          python3 .github/scripts/select_runners.py --name "" --os any --group any
+
+  collect:
+    needs: list-runners
+    strategy:
+      fail-fast: false   # one unreachable runner must not abort the sweep
+      matrix:
+        include: ${{ fromJson(needs.list-runners.outputs.matrix) }}
+
+    runs-on: [self-hosted, "${{ matrix.runner }}"]
+    steps:
+      - name: Collect specs (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          out="specs-${{ runner.name }}.txt"
+          {
+            echo "===== ${{ runner.name }} (Linux) ====="
+            echo "collected: $(date -Iseconds)"
+            echo
+            echo "----- CPU (lscpu) -----"
+            lscpu 2>/dev/null || echo "lscpu unavailable"
+            echo
+            echo "----- Memory (free -h) -----"
+            free -h 2>/dev/null || echo "free unavailable"
+            echo
+            echo "----- DIMMs (dmidecode) -----"
+            # dmidecode needs root; best-effort, never fail the step
+            sudo -n dmidecode -t memory 2>/dev/null | grep -E "Size|Type:|Speed" | grep -v "No Module" || echo "dmidecode unavailable (needs root)"
+            echo
+            echo "----- GPU (rocm-smi) -----"
+            rocm-smi --showproductname --showmeminfo vram 2>/dev/null || echo "rocm-smi unavailable"
+            echo
+            echo "----- GPU (lspci) -----"
+            lspci 2>/dev/null | grep -iE "vga|display|3d" || echo "lspci unavailable"
+          } > "$out"
+          cat "$out"
+
+      - name: Collect specs (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          $out = "specs-${{ runner.name }}.txt"
+          $lines = @()
+          $lines += "===== ${{ runner.name }} (Windows) ====="
+          $lines += "collected: $(Get-Date -Format o)"
+          $lines += ""
+          $lines += "----- CPU -----"
+          $lines += (Get-CimInstance Win32_Processor |
+            Select-Object Name, NumberOfCores, NumberOfLogicalProcessors, MaxClockSpeed |
+            Format-List | Out-String).Trim()
+          $lines += ""
+          $lines += "----- Memory (total) -----"
+          $totalGB = [math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1GB, 1)
+          $lines += "TotalPhysicalMemory: $totalGB GB"
+          $lines += ""
+          $lines += "----- DIMMs -----"
+          $lines += (Get-CimInstance Win32_PhysicalMemory |
+            Select-Object @{n='SizeGB';e={[math]::Round($_.Capacity/1GB,1)}}, Speed, Manufacturer, PartNumber |
+            Format-Table -AutoSize | Out-String).Trim()
+          $lines += ""
+          $lines += "----- GPU (Win32_VideoController) -----"
+          $lines += (Get-CimInstance Win32_VideoController |
+            Select-Object Name, @{n='VRAM_GB';e={[math]::Round($_.AdapterRAM/1GB,1)}}, DriverVersion |
+            Format-List | Out-String).Trim()
+          $lines += ""
+          $lines += "----- GPU (rocm-smi, if present) -----"
+          if (Get-Command rocm-smi -ErrorAction SilentlyContinue) {
+            $lines += (rocm-smi --showproductname --showmeminfo vram 2>$null | Out-String).Trim()
+          } else {
+            $lines += "rocm-smi unavailable"
+          }
+          $lines -join "`r`n" | Out-File -FilePath $out -Encoding utf8
+          Get-Content $out
+
+      - name: Upload specs artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runner-specs-${{ runner.name }}
+          path: specs-${{ runner.name }}.txt
+          retention-days: 14
+
+  combine:
+    name: Combine specs
+    needs: collect
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all spec artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: runner-specs-*
+          path: specs
+          merge-multiple: true
+
+      - name: Write combined summary
+        run: |
+          {
+            echo "# Runner fleet specs"
+            echo
+            for f in specs/specs-*.txt; do
+              [ -f "$f" ] || continue
+              echo '```'
+              cat "$f"
+              echo '```'
+              echo
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/collect-runner-specs.yml
+++ b/.github/workflows/collect-runner-specs.yml
@@ -33,12 +33,34 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build runner matrix from runners.json
-        id: list
+        id: fleet
         run: |
           python3 .github/scripts/select_runners.py --name "" --os any --group any
 
+      # select_runners.py only covers the device fleet in runners.json (18
+      # machines). Append the standalone self-hosted boxes that are registered
+      # to the repo but intentionally left out of the CI matrix, so the
+      # inventory is complete. Keep this list in sync with the repo's
+      # Settings -> Actions -> Runners page.
+      - name: Append non-fleet machines
+        id: list
+        env:
+          FLEET_MATRIX: ${{ steps.fleet.outputs.matrix }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os
+          fleet = json.loads(os.environ["FLEET_MATRIX"])
+          extras = [
+              {"runner": "CS-UCICD-DT208"},   # generic Windows, no device label
+              {"runner": "MNB-DGPU-DT3410"},  # Linux, translation workflow
+              {"runner": "x-ultra"},          # Linux, experimental one-off
+          ]
+          print("matrix=" + json.dumps(fleet + extras))
+          PY
+
   collect:
     needs: list-runners
+    timeout-minutes: 10   # an offline box must not pin a job for hours
     strategy:
       fail-fast: false   # one unreachable runner must not abort the sweep
       matrix:
@@ -118,9 +140,50 @@ jobs:
           path: specs-${{ runner.name }}.txt
           retention-days: 14
 
+  # The arc-lnx-pub scale set is ephemeral Kubernetes pods (org-level, shared
+  # into this repo), not a fixed machine. Profiling one pod reports the
+  # container's cgroup-granted CPU/memory, not physical hardware -- captured
+  # here for completeness and labeled as such. No GPU is expected.
+  collect-arc:
+    name: Collect specs (ARC pod)
+    timeout-minutes: 10
+    runs-on: arc-lnx-pub
+    steps:
+      - name: Collect specs (ARC ephemeral pod)
+        shell: bash
+        run: |
+          out="specs-arc-lnx-pub.txt"
+          {
+            echo "===== arc-lnx-pub (ARC ephemeral Kubernetes pod) ====="
+            echo "NOTE: figures below are the container's cgroup limits, not a physical machine."
+            echo "collected: $(date -Iseconds)"
+            echo "pod host: $(hostname 2>/dev/null || echo unknown)"
+            echo
+            echo "----- CPU (lscpu) -----"
+            lscpu 2>/dev/null || echo "lscpu unavailable"
+            echo
+            echo "----- cgroup CPU quota -----"
+            cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo "cpu.max unavailable"
+            echo
+            echo "----- Memory (free -h) -----"
+            free -h 2>/dev/null || echo "free unavailable"
+            echo
+            echo "----- cgroup memory limit -----"
+            cat /sys/fs/cgroup/memory.max 2>/dev/null || echo "memory.max unavailable"
+          } > "$out"
+          cat "$out"
+
+      - name: Upload ARC specs artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runner-specs-arc-lnx-pub
+          path: specs-arc-lnx-pub.txt
+          retention-days: 14
+
   combine:
     name: Combine specs
-    needs: collect
+    needs: [collect, collect-arc]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
Adds a **read-only, on-demand** workflow (`workflow_dispatch`) that inventories the hardware of every runner attached to this repo and reports CPU, memory, and GPU/VRAM per runner — as per-runner artifacts plus a combined step summary.

Motivation: the device tags in `runners.json` (`halo`, `stx`, `krk`, `rx7900xt`, `rx9070xt`, `r9700`) don't record actual specs (CPU model, installed RAM, VRAM). This lets the fleet report its own specs instead of maintaining them by hand or SSHing in.

## What it covers
- **18 device-fleet machines** — via `select_runners.py` (same source of truth as Runner Heartbeat).
- **3 standalone self-hosted boxes** registered to the repo but omitted from `runners.json`: `CS-UCICD-DT208`, `MNB-DGPU-DT3410` (translation), `x-ultra`.
- **`arc-lnx-pub` ARC scale set** — one ephemeral pod, profiling its cgroup CPU/memory limits (clearly labeled as a container, not physical hardware).

## Design notes
- Modeled on `runner-heartbeat.yml`'s fleet-matrix pattern.
- Read-only hardware queries only. The single privileged call is `sudo -n dmidecode` (non-interactive; degrades gracefully if unavailable).
- `fail-fast: false` + `timeout-minutes: 10` + `if: always()` uploads, so one offline runner can't abort or hang the sweep.
- `workflow_dispatch` only — no schedule.

## Why it must merge to run
`workflow_dispatch` workflows are only dispatchable once the file is on the default branch (`main`). After merge: **Actions → Collect Runner Specs → Run workflow**, then read the combined step summary or download the `runner-specs-*` artifacts.

## Test plan
- [ ] Merge to `main`
- [ ] Dispatch and confirm all 4 jobs (`list-runners`, `collect`, `collect-arc`, `combine`) run
- [ ] Verify the combined summary shows specs for the fleet + extras + ARC pod