### PR TITLE
fix: remove stray backtick in hermes-lemonade-server README podman install

### DIFF
--- a/playbooks/supplemental/hermes-lemonade-server/README.md
+++ b/playbooks/supplemental/hermes-lemonade-server/README.md
@@ -47,7 +47,7 @@ By the end of this playbook you will be able to:
 - **~10–30 GB of free disk space** for model weights
 - [Podman](https://podman.io/docs/installation) (Optional, for sandboxing Hermes Agent)
   ```bash 
-  sudo apt-get install -y podman`
+  sudo apt-get install -y podman
   ```
 <!-- @os:end -->
 


### PR DESCRIPTION
Remove stray backtick in playbooks/supplemental/hermes-lemonade-server/README.md