### PR TITLE
orchestrai: enable krk now that Kraken hardware is in the farm; own the CI files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,16 @@ test_*.py @sreeram-11
 # the translation trees never run playbook CI (translations are not tested).
 /auto-translations/ @bconsolvo
 /localized-playbooks/ @bconsolvo
+
+# OrchestrAI CI integration. CODEOWNERS is last-match-wins, so these lines would
+# REPLACE the owner from `/.github/` above rather than add to it -- @danielholanda
+# is repeated on each so ownership of these files is widened, not narrowed.
+/.github/orchestrai-config.yml                          @danielholanda @saman-amd
+/.github/scripts/orchestrai_matrix.py                   @danielholanda @saman-amd
+/.github/scripts/orchestrai_trigger.py                  @danielholanda @saman-amd
+/.github/scripts/orchestrai_verdict.py                  @danielholanda @saman-amd
+/.github/scripts/orchestrai_report.py                   @danielholanda @saman-amd
+/.github/workflows/test-playbooks-orchestrai.yml        @danielholanda @saman-amd
+/.github/workflows/orchestrai-pr-command.yml            @danielholanda @saman-amd
+/.github/workflows/test-localized-playbooks-orchestrai.yml @danielholanda @saman-amd
+/.github/workflows/orchestrai-localized-pr-command.yml  @danielholanda @saman-amd

--- a/.github/orchestrai-config.yml
+++ b/.github/orchestrai-config.yml
@@ -179,7 +179,12 @@ extra_install_scripts:
       platforms: ["windows"]
 
 # Devices to skip entirely (e.g. temporarily offline hardware).
-skip_devices: ["krk"]
+# krk was listed here only because there was no Kraken hardware in the farm.
+# There is now (apu_krk), so it is enabled. NOTE: enabling a device here is
+# necessary but NOT sufficient -- the matrix drops any device missing from the
+# ORCHESTRAI_DEVICE_TAGS repo variable, with a ::warning::, so that variable
+# needs a "krk" entry pointing at the fleet tag before this has any effect.
+skip_devices: []
 
 # Skip ONE playbook on ONE device, where skip_devices would be too broad: the
 # device works fine for everything else. Keyed by playbook id -> device list.
@@ -197,9 +202,18 @@ skip_devices: ["krk"]
 # Every stx in the farm is currently 32 GB. REMOVE these entries when either
 # lands: 64 GB stx machines, or a device-scoped @var model for stx (note the
 # tests also require ctx_size=262144, so a smaller model alone may not suffice).
+#
+# krk is skipped for the same two playbooks, for a slightly different reason:
+# the Kraken fleet is MIXED (one 32 GB machine and four 64 GB ones). The model
+# fits on the 64 GB hosts and misses the 80% ceiling on the 32 GB one, so which
+# result you get depends on which machine the broker hands out -- a coin flip
+# reported as a playbook failure. Skipping is deterministic. The alternative, if
+# these two should run on Kraken, is to give them a ram_64gb extra tag on krk
+# (device_extra_tags) and add krk to extra_tag_devices[ram_64gb); that pins them
+# to the four large hosts instead of excluding them.
 skip_playbook_devices:
-  hermes-lemonade-server:  ["stx"]
-  openclaw-lemonade-server: ["stx"]
+  hermes-lemonade-server:  ["stx", "krk"]
+  openclaw-lemonade-server: ["stx", "krk"]
   # LM Studio's survey exposed 10.71 GiB to Vulkan on Windows STX for an
   # 18.63 GB model; Windows failed with "unable to allocate Vulkan0 buffer".
   # Linux aborted at 91% while amdgpu reported insufficient submission memory.


### PR DESCRIPTION
## Enabling krk

`krk` was in `skip_devices` only because there was no Kraken hardware. There is now — **5 machines tagged `apu_krk`, all warm**: `HYD-AUD-CRB28`, `MNB-UCICD-DT548..551`.

`device_to_gfx` (gfx1103) and `device_families` (ryzen_apu) already carried krk, so `skip_devices` was the only thing holding it back. 16 playbooks declare krk in `tested_platforms`; enabling it adds **28 matrix entries** as two 14-playbook batches (`linux/krk`, `windows/krk`).

### ⚠️ This is a no-op until a repo variable changes

The matrix drops any device missing from `ORCHESTRAI_DEVICE_TAGS` with a `::warning::` rather than failing, so **this PR does nothing on its own**. `ORCHESTRAI_DEVICE_TAGS` needs:

```json
"krk": ["apu_krk"]
```

I don't have access to set repo variables. Note `apu_krk2e` (7 more machines) is a **separate tag** and is deliberately not included — different SKU, and it should be its own device entry if you want it.

## Two playbooks held back, one deliberately not

**`hermes-lemonade-server` and `openclaw-lemonade-server` are skipped on krk**, for the same arithmetic that already skips them on stx. Both pin `Qwen3.6-35B-A3B-GGUF` (23.3 GB) and lemonade refuses anything above 80% of system RAM. The Kraken fleet is **mixed — one 32 GB machine and four 64 GB ones** — so the model fits on the large hosts and misses the ceiling on the small one. Which result you get depends on which machine the broker hands out: a coin flip reported as a playbook failure.

If you'd rather run them on Kraken, the alternative is a `ram_64gb` extra tag on krk plus a matching `extra_tag_devices` entry — that pins them to the four large hosts instead of excluding them. Say the word and I'll switch it.

**`vscode-qwen3-coder` is left enabled on krk**, on purpose. It's skipped on stx for *Vulkan shared-memory* reasons (10.71 GiB exposed for an 18.63 GB model), not system RAM, and I have no gfx1103 data to predict that. It's the most likely first failure on the 32 GB Kraken — but that's worth learning from a run rather than pre-emptively dropping coverage on a guess.

## CODEOWNERS

Adds the OrchestrAI CI files. **CODEOWNERS is last-match-wins**, so a narrower rule *replaces* the owner from the existing `/.github/ @danielholanda` line rather than adding to it. `@danielholanda` is therefore repeated on every new entry, so ownership of these files is **widened, not narrowed**.

One thing to confirm: a CODEOWNERS entry only takes effect if the owner has **write access to the repo**. I couldn't verify `@saman-amd`'s permission on `amd/playbooks` from here (the API needs push access to answer), and the PRs from that account come from a fork, which suggests it may not be a collaborator. If it isn't, GitHub will flag the entry as an unknown owner and silently not request review. Worth checking before merge — an internal `@…-amd` account may be the right handle instead.

## Verification

`orchestrai_matrix.py` over every `playbook.json`, with a stub tag map:

```
linux/krk:   14 playbooks
windows/krk: 14 playbooks
total matrix entries: 156 -> 184
krk entries: 0 -> 28
hermes/openclaw on krk: []   (correctly excluded)
```
