### PR TITLE
orchestrai: report infrastructure failures as NOT_RUN, not as test failures

### DIFF
--- a/.github/scripts/orchestrai_report.py
+++ b/.github/scripts/orchestrai_report.py
@@ -11,9 +11,16 @@ Aggregates the per-playbook test-results artifacts produced by the matrix job
 into a single Markdown body for the !orc sticky PR comment.
 
 Each artifact is a directory named `test-results-<playbook>-<platform>-<arch>`
-containing summary.json ({playbook_id, platform, passed, failed, ...}). This
-walks the download dir, reads each summary, and prints the comment body
+containing summary.json ({playbook_id, platform, passed, failed, outcome, ...}).
+This walks the download dir, reads each summary, and prints the comment body
 (prefixed with a stable marker so the workflow can upsert one sticky comment).
+
+Playbooks that never ran (outcome NOT_RUN/INTERRUPTED) are reported as
+infrastructure, in their own category — not as test failures — and the shared
+`infrastructure_reason` is stated once rather than once per playbook.
+
+Artifacts written by an older verdict script carry no `outcome`; those fall back
+to the previous pass/fail derivation.
 
 Usage:
     orchestrai_report.py --artifacts <dir> [--run-url URL] [--sha SHA] [--ref REF]
@@ -28,20 +35,42 @@ import os
 
 MARKER = "<!-- orchestrai-orc-report -->"
 
+PASS, FAIL, INFRA = "pass", "fail", "infra"
 
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--artifacts", required=True)
-    ap.add_argument("--run-url", default="")
-    ap.add_argument("--sha", default="")
-    ap.add_argument("--ref", default="")
-    args = ap.parse_args()
+INFRA_OUTCOMES = ("NOT_RUN", "INTERRUPTED")
 
+_CELL = {
+    PASS: "✅ pass",
+    FAIL: "❌ fail",
+    INFRA: "⚠️ not run",
+}
+
+
+def classify(d):
+    """(category, outcome_label) for one summary.json document."""
+    outcome = (d.get("outcome") or "").strip().upper()
+    if outcome in INFRA_OUTCOMES:
+        return INFRA, outcome
+    if outcome == "PASSED":
+        return PASS, outcome
+    if outcome == "FAILED":
+        return FAIL, outcome
+    # Legacy artifact with no `outcome`: derive as before.
+    passed = int(d.get("passed", 0) or 0)
+    failed = int(d.get("failed", 0) or 0)
+    return (PASS if (failed == 0 and passed > 0) else FAIL), ""
+
+
+def collect(artifacts_dir):
+    """Rows of (playbook, platform, arch, category, infrastructure_reason)."""
     rows = []
-    for path in glob.glob(os.path.join(args.artifacts, "**", "summary.json"), recursive=True):
+    for path in glob.glob(os.path.join(artifacts_dir, "**", "summary.json"), recursive=True):
         try:
-            d = json.load(open(path))
+            with open(path) as f:
+                d = json.load(f)
         except Exception:
+            continue
+        if not isinstance(d, dict):
             continue
         pb = d.get("playbook_id", "?")
         platform = d.get("platform", "?")
@@ -53,34 +82,91 @@ def main():
             parts = dirname[len("test-results-"):].rsplit("-", 2)
             if len(parts) == 3:
                 arch = parts[2]
-        passed = int(d.get("passed", 0) or 0)
-        failed = int(d.get("failed", 0) or 0)
-        ok = failed == 0 and passed > 0
-        rows.append((pb, platform, arch, ok))
-
+        category, _ = classify(d)
+        reason = d.get("infrastructure_reason") if category == INFRA else None
+        if not isinstance(reason, str) or not reason.strip():
+            reason = None
+        rows.append((pb, platform, arch, category, reason))
     rows.sort(key=lambda r: (r[0], r[1], r[2]))
-    n_pass = sum(1 for r in rows if r[3])
-    n_fail = len(rows) - n_pass
-    overall = "✅ all passed" if rows and n_fail == 0 else (
-        "❌ failures" if rows else "⚠️ no results")
+    return rows
 
-    lines = [MARKER, f"### OrchestrAI results — {overall} ({n_pass} passed, {n_fail} failed)", ""]
+
+def _headline(n_pass, n_fail, n_infra):
+    parts = []
+    if n_fail:
+        parts.append(f"❌ {n_fail} failed")
+    if n_infra:
+        parts.append(f"⚠️ {n_infra} not run (infrastructure)")
+    if n_pass:
+        parts.append(f"✅ {n_pass} passed")
+    if not parts:
+        return "⚠️ no results"
+    if not n_fail and not n_infra:
+        return f"✅ all passed ({n_pass} passed)"
+    return ", ".join(parts)
+
+
+def _infra_notes(rows):
+    """One line per distinct infrastructure reason — never one per playbook."""
+    order, counts = [], {}
+    for _, _, _, category, reason in rows:
+        if category != INFRA:
+            continue
+        key = reason or "reason not reported by the pipeline"
+        if key not in counts:
+            order.append(key)
+            counts[key] = 0
+        counts[key] += 1
+
+    lines = []
+    for reason in order:
+        n = counts[reason]
+        noun = "playbook" if n == 1 else "playbooks"
+        lines.append(f"> ⚠️ **{n} {noun} did not run** — infrastructure: {reason}")
+    if lines:
+        lines.append("")
+        lines.append("_Not-run playbooks are an infrastructure problem with the batch, "
+                     "not test failures._")
+    return lines
+
+
+def render(rows, run_url="", sha="", ref=""):
+    n_pass = sum(1 for r in rows if r[3] == PASS)
+    n_fail = sum(1 for r in rows if r[3] == FAIL)
+    n_infra = sum(1 for r in rows if r[3] == INFRA)
+
+    lines = [MARKER, f"### OrchestrAI results — {_headline(n_pass, n_fail, n_infra)}", ""]
     if rows:
         lines += ["| Playbook | Platform | Device | Result |", "|---|---|---|---|"]
-        for pb, platform, arch, ok in rows:
-            lines.append(f"| `{pb}` | {platform} | {arch} | {'✅ pass' if ok else '❌ fail'} |")
+        for pb, platform, arch, category, _ in rows:
+            lines.append(f"| `{pb}` | {platform} | {arch} | {_CELL[category]} |")
+        notes = _infra_notes(rows)
+        if notes:
+            lines.append("")
+            lines += notes
     else:
         lines.append("_No playbooks were scheduled (nothing matched, or all devices were skipped)._")
     lines.append("")
     foot = []
-    if args.sha:
-        foot.append(f"tested `{args.sha[:8]}`" + (f" ({args.ref})" if args.ref else ""))
-    if args.run_url:
-        foot.append(f"[workflow run]({args.run_url}) — per-playbook ReportPortal links are in each job summary")
+    if sha:
+        foot.append(f"tested `{sha[:8]}`" + (f" ({ref})" if ref else ""))
+    if run_url:
+        foot.append(f"[workflow run]({run_url}) — per-playbook ReportPortal links are in each job summary")
     if foot:
         lines.append(" · ".join(foot))
+    return "\n".join(lines)
 
-    print("\n".join(lines))
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--artifacts", required=True)
+    ap.add_argument("--run-url", default="")
+    ap.add_argument("--sha", default="")
+    ap.add_argument("--ref", default="")
+    args = ap.parse_args()
+
+    print(render(collect(args.artifacts), run_url=args.run_url, sha=args.sha,
+                 ref=args.ref))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/orchestrai_verdict.py
+++ b/.github/scripts/orchestrai_verdict.py
@@ -11,11 +11,31 @@ A batch build runs several playbooks on one machine, so the OrchestrAI pipeline 
 overall result can't tell us whether THIS playbook passed. The pipeline writes a
 per-group rollup to its summary.json:
 
-    groups["playbook-<id>"] = {passed, failed, skipped, errors, status}
+    groups["playbook-<id>"] = {passed, failed, skipped, errors, status,
+                               infrastructure_reason}
+    expected_groups = ["playbook-a", ...]          # every group the batch planned
 
 keyed by the submission group id (independent of completion order). This script
 resolves THIS playbook's verdict, preferring that rollup and falling back to the
 build console's per-suite lifecycle if the rollup is absent.
+
+Infrastructure vs test failure
+------------------------------
+A group can be NOT_RUN (planned but never scheduled) or INTERRUPTED (started but
+produced nothing) — e.g. the machine never came back from a reboot. That is an
+infrastructure problem for the whole batch, NOT a failure of this playbook, so
+the verdict is reported separately and `failed` is never fabricated to 1.
+
+Backward compatibility: a summary.json without `expected_groups`/`NOT_RUN`
+(old pipeline) is treated exactly as before — a missing group falls back to the
+console and then to a hard failure.
+
+An artifact is ALWAYS written
+-----------------------------
+`upload-artifact` runs with `if-no-files-found: ignore`, so a crash here makes
+the playbook disappear from the aggregated report entirely and the sticky
+comment silently undercounts. Every exit path — including an unexpected
+exception and a malformed summary.json — writes test-results/summary.json first.
 
 Usage:
     orchestrai_verdict.py     (all inputs via env)
@@ -24,9 +44,10 @@ Env:
     BUILD_URL, ORCHESTRAI_PIPELINE_USER, ORCHESTRAI_PIPELINE_TOKEN, PLAYBOOK_ID, PLATFORM
 
 Outputs:
-    test-results/summary.json   (per-playbook counts, for artifact upload)
+    test-results/summary.json   (per-playbook counts + outcome, for artifact upload)
     rp_url=<reportportal launch url>  -> $GITHUB_OUTPUT
-    exit 0 if PASSED, 1 otherwise (including: no verdict found for this playbook)
+    exit 0 PASSED, 1 FAILED (a real test failure), 2 NOT_RUN/INTERRUPTED
+    (infrastructure — the playbook never produced results)
 """
 
 import base64
@@ -38,11 +59,31 @@ import urllib.request
 
 COUNT_KEYS = ("passed", "failed", "skipped", "errors")
 
+# Statuses that mean "this playbook never produced results" rather than
+# "this playbook failed its tests".
+INFRA_STATUSES = ("NOT_RUN", "INTERRUPTED")
+
+EXIT_PASSED = 0
+EXIT_FAILED = 1
+EXIT_INFRA = 2
+
 FETCH_TIMEOUT = 60
+
+# Reasons reported when there is nothing to judge this playbook by. These are
+# infrastructure conditions, never test failures.
+REASON_NO_BUILD = "no OrchestrAI build was produced for this batch"
+REASON_NO_SUMMARY = "could not retrieve the build summary"
+REASON_BAD_SUMMARY = "the build summary was malformed (groups is not an object)"
 
 
 def fetch(url, user, token):
-    """GET `url` with basic auth, returning "" on any failure.
+    """GET `url` with basic auth.
+
+    Returns the body (possibly "") on a successful response, and None on a
+    transport failure — 401, DNS/connection error, an aborted build with no
+    artifact. The caller must be able to tell "the pipeline said nothing" from
+    "we could not reach the pipeline": the first is a real (if empty) answer,
+    the second is infrastructure and must never be turned into a test failure.
 
     SECURITY: the credentials are deliberately NOT handed to a `curl -u
     user:token` subprocess. argv is world-readable via /proc/<pid>/cmdline and
@@ -58,17 +99,54 @@ def fetch(url, user, token):
         with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT) as r:
             return r.read().decode("utf-8", "replace")
     except Exception:
-        return ""
+        return None
+
+
+def normalise_groups(summary):
+    """(groups_dict, malformed) for `summary["groups"]`.
+
+    The pipeline is supposed to emit an object here; anything else (a list, a
+    string, a number) is a malformed document. Coercing to {} in ONE place
+    keeps every later `.get()` safe — the previous code did
+    `(summary.get("groups") or {}).get(...)`, which still raises AttributeError
+    on a truthy non-dict and left no artifact behind.
+    """
+    raw = summary.get("groups")
+    if isinstance(raw, dict):
+        return raw, False
+    return {}, raw is not None
+
+
+def group_counts(grp):
+    """The four count keys of a group rollup, coerced to ints."""
+    out = {}
+    for k in COUNT_KEYS:
+        try:
+            out[k] = int(grp.get(k) or 0)
+        except (TypeError, ValueError):
+            out[k] = 0
+    return out
 
 
 def status_from_group(grp):
-    """PASSED/FAILED from a group rollup, or None if it carries no verdict
-    (no status field and zero counts — i.e. nothing actually ran)."""
-    status = grp.get("status")
+    """Verdict from a group rollup, or None if it carries none.
+
+    NOT_RUN/INTERRUPTED are passed through so the caller can report them as
+    infrastructure rather than as a test failure. A group claiming PASSED while
+    having run nothing is never believed (that is the bug this guards): with
+    zero counts it can only be INTERRUPTED.
+    """
+    status = (grp.get("status") or "").strip().upper() or None
+    counts = group_counts(grp)
+    ran_something = sum(counts.values()) > 0
+
+    if status in INFRA_STATUSES:
+        return status
+    if status == "PASSED" and not ran_something:
+        return "INTERRUPTED"
     if status:
         return status
-    counts = {k: grp.get(k) or 0 for k in COUNT_KEYS}
-    if sum(counts.values()) == 0:
+    if not ran_something:
         return None  # ambiguous: group exists but ran nothing — don't call it PASS
     return "FAILED" if (counts["failed"] or counts["errors"]) else "PASSED"
 
@@ -80,6 +158,7 @@ def status_from_console(console, playbook):
         Finished item <sid> -> PASSED|FAILED
     """
     esc = re.escape(playbook)
+    console = console or ""   # fetch() returns None when the console is unreachable
     m = re.search(rf'Started suite "playbook-{esc} #\d+".*?id=([0-9a-fA-F-]+)', console)
     if not m:
         return None
@@ -92,7 +171,130 @@ def status_from_console(console, playbook):
     return fin[-1] if fin else None
 
 
-def main():
+def has_infra_schema(summary):
+    """True when the pipeline speaks the infrastructure-aware schema.
+
+    Old pipelines emit neither `expected_groups` nor a batch INTERRUPTED status
+    nor a batch `infrastructure_reason`; for those we must degrade to the
+    previous behaviour (missing group -> console -> hard failure).
+    """
+    if isinstance(summary.get("expected_groups"), list):
+        return True
+    if (summary.get("status") or "").strip().upper() == "INTERRUPTED":
+        return True
+    return summary.get("infrastructure_reason") is not None
+
+
+def infrastructure_reason(summary, grp, group_key):
+    """The reason to report for a NOT_RUN/INTERRUPTED group.
+
+    Per-group reason wins over the batch-level one; if the pipeline supplied
+    neither, describe the shortfall from expected_groups vs groups.
+    """
+    for src in (grp, summary):
+        if isinstance(src, dict):
+            reason = src.get("infrastructure_reason")
+            if isinstance(reason, str) and reason.strip():
+                return reason.strip()
+
+    expected = summary.get("expected_groups")
+    groups, _ = normalise_groups(summary)
+    if isinstance(expected, list) and expected:
+        missing = [g for g in expected if g not in groups]
+        if group_key not in expected:
+            return (f"{group_key} is not in the batch plan "
+                    f"({len(expected)} playbooks were planned)")
+        if missing:
+            return (f"batch did not complete; {len(missing)} of {len(expected)} "
+                    f"playbooks never ran")
+    return "batch did not complete; this playbook produced no results"
+
+
+def build_results(playbook, outcome, grp, reason):
+    """The single `results` row for the artifact.
+
+    Never empty: an artifact with `results: []` hides what actually happened,
+    which is exactly how 13 never-executed playbooks looked like 13 failures.
+
+    The row is a SUPERSET of the row schema the website dashboard already reads
+    (`{test_id, success, skipped, duration, error_message}` —
+    website/src/lib/github-test-results.ts, produced by run_playbook_tests.py),
+    plus an additive `status`. Inventing a second shape for the same filename
+    would break every existing consumer of this artifact.
+    """
+    if outcome in INFRA_STATUSES:
+        message = reason or "the playbook produced no results"
+    elif isinstance(grp, dict):
+        c = group_counts(grp)
+        message = (f"{c['passed']} passed, {c['failed']} failed, "
+                   f"{c['skipped']} skipped, {c['errors']} errors")
+    elif outcome == "PASSED":
+        message = "playbook suite passed (per-test detail not reported by the pipeline)"
+    else:
+        message = "playbook suite did not pass (per-test detail not reported by the pipeline)"
+
+    return [{
+        "test_id": playbook,
+        "success": outcome == "PASSED",
+        # NOT_RUN/INTERRUPTED is closer to "skipped" than to "failed" for a
+        # consumer that only knows success/skipped — it must not be counted red.
+        "skipped": outcome in INFRA_STATUSES,
+        "duration": 0,
+        "error_message": "" if outcome == "PASSED" else message,
+        "status": outcome,
+    }]
+
+
+def make_summary(playbook, platform, outcome, grp=None, reason=None,
+                 summary=None):
+    """The per-playbook test-results/summary.json document."""
+    summary = summary if isinstance(summary, dict) else {}
+
+    if isinstance(grp, dict):
+        c = group_counts(grp)
+        # Errors are test outcomes too; fold them into `failed` so consumers
+        # that only look at `failed` cannot miss them.
+        passed, failed, skipped = c["passed"], c["failed"] + c["errors"], c["skipped"]
+    elif outcome in INFRA_STATUSES:
+        passed = failed = skipped = 0
+    else:
+        # Console fallback: no counts available, keep the historical 1-test shape.
+        passed, failed, skipped = (1, 0, 0) if outcome == "PASSED" else (0, 1, 0)
+
+    total = passed + failed + skipped
+    if outcome == "PASSED" and total == 0:
+        # Contract: never emit PASSED with nothing behind it.
+        outcome, reason = "INTERRUPTED", reason or "no tests were recorded for this playbook"
+
+    return {
+        "playbook_id": playbook,
+        "platform": platform,
+        "total_tests": total,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "outcome": outcome,
+        "infrastructure_reason": reason if outcome in INFRA_STATUSES else None,
+        "reportportal_url": (summary.get("rp_launch_url") or None),
+        "results": build_results(playbook, outcome, grp, reason),
+    }
+
+
+def exit_code_for(outcome):
+    if outcome == "PASSED":
+        return EXIT_PASSED
+    if outcome in INFRA_STATUSES:
+        return EXIT_INFRA
+    return EXIT_FAILED
+
+
+def write_artifact(doc):
+    os.makedirs("test-results", exist_ok=True)
+    with open("test-results/summary.json", "w") as f:
+        json.dump(doc, f, indent=2)
+
+
+def _run():
     user = os.environ.get("ORCHESTRAI_PIPELINE_USER", "")
     token = os.environ.get("ORCHESTRAI_PIPELINE_TOKEN", "")
     build_url = os.environ.get("BUILD_URL", "")
@@ -102,28 +304,44 @@ def main():
     if not playbook or not platform:
         print("::error::orchestrai_verdict.py: PLAYBOOK_ID and PLATFORM must be set",
               file=sys.stderr)
-        sys.exit(1)
+        sys.exit(EXIT_FAILED)
 
     group_key = f"playbook-{playbook}"
-    os.makedirs("test-results", exist_ok=True)
 
-    def write_summary(ok):
-        json.dump(
-            {"playbook_id": playbook, "platform": platform, "total_tests": 1,
-             "passed": 1 if ok else 0, "failed": 0 if ok else 1,
-             "skipped": 0, "results": []},
-            open("test-results/summary.json", "w"), indent=2)
+    def finish(status, grp=None, reason=None, summary=None, how=""):
+        """Write the artifact, annotate, and exit with the mapped code."""
+        doc = make_summary(playbook, platform, status, grp=grp, reason=reason,
+                           summary=summary)
+        write_artifact(doc)
+        outcome = doc["outcome"]
+        code = exit_code_for(outcome)
+        if code == EXIT_INFRA:
+            print(f"::warning::{playbook} ({platform}): {outcome} — "
+                  f"{doc['infrastructure_reason']} (infrastructure, not a test failure)")
+        counts = group_counts(grp) if isinstance(grp, dict) else {}
+        print(f"{playbook} ({platform}): {outcome} (via {how}, counts={counts})")
+        sys.exit(code)
 
+    # No build URL at all: the batch never produced a build, so this playbook —
+    # and every other playbook in the same batch — never ran. That is
+    # infrastructure, not 13 (or 79) test failures.
     if not build_url:
-        write_summary(False)
-        print(f"::error::No OrchestrAI pipeline build URL for {playbook} ({platform})")
-        sys.exit(1)
+        # Deliberately NOT ::error:: — finish() immediately annotates this as
+        # infrastructure, and emitting an error first contradicts that in the
+        # very place a reader looks to tell the two apart.
+        print(f"No OrchestrAI pipeline build URL for {playbook} ({platform})")
+        finish("NOT_RUN", reason=REASON_NO_BUILD, how="no build url")
 
-    raw = fetch(f"{build_url}artifact/.pipeline/summary.json", user, token) or "{}"
+    raw = fetch(f"{build_url}artifact/.pipeline/summary.json", user, token)
+    summary_unreachable = raw is None
     try:
-        summary = json.loads(raw)
+        summary = json.loads(raw or "{}")
     except Exception:
         summary = {}
+    if not isinstance(summary, dict):
+        summary = {}
+
+    groups, groups_malformed = normalise_groups(summary)
 
     out = os.environ.get("GITHUB_OUTPUT")
     if out:
@@ -132,13 +350,17 @@ def main():
 
     # Primary: per-group rollup in summary.json.
     status, how = None, ""
-    grp = (summary.get("groups") or {}).get(group_key)
-    if isinstance(grp, dict):
+    grp = groups.get(group_key)
+    if not isinstance(grp, dict):
+        grp = None
+    if grp is not None:
         status = status_from_group(grp)
         if status:
             how = "summary.json groups"
 
-    # Fallback: scrape the build console's suite lifecycle.
+    # Fallback: scrape the build console's suite lifecycle. A readable console
+    # still wins over everything below — only if IT is silent too do we decide
+    # between infrastructure and a hard failure.
     if status is None:
         console = fetch(f"{build_url}consoleText", user, token)
         status = status_from_console(console, playbook)
@@ -146,19 +368,62 @@ def main():
             how = "console suite lifecycle"
 
     if status is None:
-        write_summary(False)
-        groups_present = list((summary.get("groups") or {}).keys())
+        # Neither source answered. Decide whether that is infrastructure or a
+        # genuine "this playbook was expected to report and did not".
+        if summary_unreachable:
+            # 401, network, aborted build: we could not read the build summary
+            # at all. Distinguishable from a legitimately empty document
+            # precisely because fetch() returns None rather than "".
+            finish("NOT_RUN", reason=REASON_NO_SUMMARY, summary=summary,
+                   how="build summary unreachable")
+        if groups_malformed:
+            finish("INTERRUPTED", reason=REASON_BAD_SUMMARY, summary=summary,
+                   how="malformed summary.json")
+        if has_infra_schema(summary):
+            # Infrastructure-aware pipeline: a planned group with no session
+            # never ran; it is not a playbook failure.
+            status = "NOT_RUN"
+            how = "expected_groups (no session for this playbook)"
+
+    if status is None:
+        # Old pipeline, readable summary, no group and no console result:
+        # today's behaviour exactly — a hard failure.
+        write_artifact(make_summary(playbook, platform, "FAILED", summary=summary))
         print(f"::error::No verdict for {playbook} ({platform}): "
               f"no groups['{group_key}'] in summary.json and no suite result in the "
-              f"console. groups present: {groups_present}")
-        sys.exit(1)
+              f"console. groups present: {list(groups.keys())}")
+        sys.exit(EXIT_FAILED)
 
-    ok = (status == "PASSED")
-    write_summary(ok)
-    counts = {k: grp.get(k) for k in COUNT_KEYS} if isinstance(grp, dict) else {}
-    print(f"{playbook} ({platform}): {'PASS' if ok else 'FAIL'} "
-          f"(status={status}, via {how}, counts={counts})")
-    sys.exit(0 if ok else 1)
+    reason = (infrastructure_reason(summary, grp, group_key)
+              if status in INFRA_STATUSES else None)
+    finish(status, grp=grp, reason=reason, summary=summary, how=how)
+
+
+def main():
+    """_run() with a guaranteed artifact.
+
+    `upload-artifact` uses `if-no-files-found: ignore`, so an uncaught exception
+    here would delete this playbook from the aggregated report rather than
+    colouring it red — the report would silently undercount, which is strictly
+    worse than a wrong count. Any unexpected error becomes INTERRUPTED (2) with
+    the error named as the infrastructure reason.
+    """
+    try:
+        _run()
+    except SystemExit:
+        raise
+    except Exception as exc:                                  # noqa: BLE001
+        playbook = os.environ.get("PLAYBOOK_ID", "") or "unknown"
+        platform = os.environ.get("PLATFORM", "") or "unknown"
+        reason = f"the verdict step failed unexpectedly: {type(exc).__name__}: {exc}"
+        try:
+            write_artifact(make_summary(playbook, platform, "INTERRUPTED",
+                                        reason=reason))
+        except Exception:                                     # noqa: BLE001
+            pass
+        print(f"::warning::{playbook} ({platform}): INTERRUPTED — {reason} "
+              f"(infrastructure, not a test failure)")
+        sys.exit(EXIT_INFRA)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_orchestrai_report.py
+++ b/.github/scripts/test_orchestrai_report.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Regression tests for orchestrai_report.py.
+
+Guards the aggregated !orc comment: playbooks that never ran must be rendered as
+their own infrastructure category (not counted as test failures), and the shared
+infrastructure_reason must be stated once — not repeated for all 13 of them.
+
+These tests drive the script through its COMMAND LINE, the same way
+orchestrai-pr-command.yml does, and assert on the rendered Markdown. That is
+deliberate: an earlier version imported internal helpers, so against the
+pre-change script every test errored with AttributeError instead of failing on
+behaviour — proving only that a refactor had happened. Going through argv means
+the pre-change script runs fine and the assertions fail on what it actually
+renders (13 never-run playbooks shown as `❌ fail`, no infrastructure section).
+
+The one structural class is marked as such.
+
+Usage:
+    python3 .github/scripts/test_orchestrai_report.py
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("orchestrai_report.py")
+
+_SPEC = importlib.util.spec_from_file_location("orchestrai_report", SCRIPT)
+report = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(report)
+
+MARKER = "<!-- orchestrai-orc-report -->"
+REASON = "host did not return from reboot"
+
+
+def artifacts(docs):
+    """Materialise {(pb, platform, arch): summary_dict} as artifact dirs."""
+    tmp = tempfile.mkdtemp()
+    for (pb, platform, arch), doc in docs.items():
+        d = Path(tmp) / f"test-results-{pb}-{platform}-{arch}"
+        d.mkdir(parents=True)
+        (d / "summary.json").write_text(json.dumps(doc))
+    return tmp
+
+
+def render(docs, **kwargs):
+    """Run the script exactly as the workflow does and return its stdout."""
+    cmd = [sys.executable, str(SCRIPT), "--artifacts", artifacts(docs)]
+    for key, value in kwargs.items():
+        cmd += [f"--{key.replace('_', '-')}", value]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    assert proc.returncode == 0, f"report script exited {proc.returncode}: {proc.stderr}"
+    return proc.stdout
+
+
+def passed(pb):
+    return {"playbook_id": pb, "platform": "linux", "total_tests": 3, "passed": 3,
+            "failed": 0, "skipped": 0, "outcome": "PASSED",
+            "infrastructure_reason": None,
+            "results": [{"test_id": pb, "success": True, "skipped": False,
+                         "duration": 0, "error_message": "", "status": "PASSED"}]}
+
+
+def failed(pb):
+    return {"playbook_id": pb, "platform": "linux", "total_tests": 3, "passed": 2,
+            "failed": 1, "skipped": 0, "outcome": "FAILED",
+            "infrastructure_reason": None,
+            "results": [{"test_id": pb, "success": False, "skipped": False,
+                         "duration": 0, "error_message": "boom", "status": "FAILED"}]}
+
+
+def not_run(pb, reason=REASON):
+    """The artifact a never-executed playbook now produces: zero counts,
+    `failed` NOT fabricated to 1, and an explicit outcome."""
+    return {"playbook_id": pb, "platform": "linux", "total_tests": 0, "passed": 0,
+            "failed": 0, "skipped": 0, "outcome": "NOT_RUN",
+            "infrastructure_reason": reason,
+            "results": [{"test_id": pb, "success": False, "skipped": True,
+                         "duration": 0, "error_message": reason, "status": "NOT_RUN"}]}
+
+
+class TestInfrastructureRendering(unittest.TestCase):
+    """The reported bug, end to end: 2 real failures + 13 playbooks that never
+    ran + 5 passes must render as three categories, not as 15 failures."""
+
+    def setUp(self):
+        docs = {}
+        for i in range(2):
+            docs[(f"fail{i}", "linux", "stx")] = failed(f"fail{i}")
+        for i in range(13):
+            docs[(f"nr{i:02d}", "linux", "stx")] = not_run(f"nr{i:02d}")
+        for i in range(5):
+            docs[(f"pass{i}", "linux", "stx")] = passed(f"pass{i}")
+        self.body = render(docs)
+
+    def test_headline_separates_the_three_categories(self):
+        self.assertIn("❌ 2 failed", self.body)
+        self.assertIn("⚠️ 13 not run (infrastructure)", self.body)
+        self.assertIn("✅ 5 passed", self.body)
+
+    def test_not_run_rows_are_not_marked_as_failures(self):
+        self.assertEqual(self.body.count("⚠️ not run"), 13)
+        self.assertEqual(self.body.count("❌ fail |"), 2)
+
+    def test_reason_is_stated_once_not_per_playbook(self):
+        self.assertEqual(self.body.count(REASON), 1)
+        self.assertIn("13 playbooks did not run", self.body)
+
+    def test_every_playbook_still_appears_in_the_table(self):
+        for i in range(13):
+            self.assertIn(f"| `nr{i:02d}` |", self.body)
+        self.assertEqual(self.body.count("| `"), 20)
+
+
+class TestOtherShapes(unittest.TestCase):
+    def test_distinct_reasons_are_grouped_separately(self):
+        docs = {("a", "linux", "stx"): not_run("a", "reboot"),
+                ("b", "linux", "stx"): not_run("b", "reboot"),
+                ("c", "linux", "stx"): not_run("c", "acquisition timed out")}
+        body = render(docs)
+        self.assertIn("2 playbooks did not run", body)
+        self.assertIn("1 playbook did not run", body)
+        self.assertEqual(body.count("reboot"), 1)
+        self.assertEqual(body.count("acquisition timed out"), 1)
+
+    def test_not_run_without_a_reason_still_renders_infrastructure(self):
+        body = render({("a", "linux", "stx"): not_run("a", None)})
+        self.assertIn("⚠️ not run", body)
+        self.assertIn("1 playbook did not run", body)
+
+    def test_interrupted_is_infrastructure_too(self):
+        doc = dict(not_run("a"), outcome="INTERRUPTED")
+        body = render({("a", "linux", "stx"): doc})
+        self.assertIn("⚠️ not run", body)
+        self.assertNotIn("❌", body)
+
+    def test_legacy_artifact_without_outcome_still_classifies(self):
+        # An artifact written by the OLD verdict script has no `outcome`; the
+        # pass/fail derivation must be byte-for-byte what it was.
+        legacy_pass = {"playbook_id": "a", "platform": "linux", "total_tests": 1,
+                       "passed": 1, "failed": 0, "skipped": 0, "results": []}
+        legacy_fail = {"playbook_id": "b", "platform": "linux", "total_tests": 1,
+                       "passed": 0, "failed": 1, "skipped": 0, "results": []}
+        body = render({("a", "linux", "stx"): legacy_pass,
+                       ("b", "linux", "stx"): legacy_fail})
+        self.assertIn("| `a` | linux | stx | ✅ pass |", body)
+        self.assertIn("| `b` | linux | stx | ❌ fail |", body)
+        self.assertNotIn("did not run", body)
+
+    def test_all_passed_has_no_infrastructure_section(self):
+        body = render({("a", "linux", "stx"): passed("a")})
+        self.assertIn("all passed", body)
+        self.assertNotIn("did not run", body)
+
+    def test_no_artifacts(self):
+        body = render({})
+        self.assertIn("no results", body)
+        self.assertIn(MARKER, body)
+
+    def test_footer_and_marker_are_preserved(self):
+        body = render({("a", "linux", "stx"): passed("a")},
+                      sha="0123456789abcdef", ref="my-branch",
+                      run_url="https://example.invalid/run/1")
+        self.assertTrue(body.startswith(MARKER))
+        self.assertIn("tested `01234567` (my-branch)", body)
+        self.assertIn("https://example.invalid/run/1", body)
+
+    def test_unreadable_artifact_is_skipped_not_fatal(self):
+        tmp = artifacts({("a", "linux", "stx"): passed("a")})
+        bad = Path(tmp) / "test-results-b-linux-stx"
+        bad.mkdir()
+        (bad / "summary.json").write_text("{not json")
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--artifacts", tmp],
+            capture_output=True, text=True, check=False)
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("| `a` |", proc.stdout)
+        self.assertNotIn("| `b` |", proc.stdout)
+
+
+class TestClassifyUnit(unittest.TestCase):
+    """STRUCTURAL: unit-level checks on the classifier introduced by this
+    change. Against the pre-change script these error (no such helper); the
+    behavioural coverage lives in the CLI-driven classes above."""
+
+    def test_classify(self):
+        self.assertEqual(report.classify({"outcome": "NOT_RUN"})[0], report.INFRA)
+        self.assertEqual(report.classify({"outcome": "INTERRUPTED"})[0], report.INFRA)
+        self.assertEqual(report.classify({"outcome": "PASSED"})[0], report.PASS)
+        self.assertEqual(report.classify({"outcome": "FAILED"})[0], report.FAIL)
+        # Legacy: no outcome -> derived from counts, exactly as before.
+        self.assertEqual(report.classify({"passed": 1, "failed": 0})[0], report.PASS)
+        self.assertEqual(report.classify({"passed": 0, "failed": 1})[0], report.FAIL)
+        self.assertEqual(report.classify({"passed": 0, "failed": 0})[0], report.FAIL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_orchestrai_verdict.py
+++ b/.github/scripts/test_orchestrai_verdict.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Regression tests for orchestrai_verdict.py.
+
+Guards three things:
+
+1. The infrastructure-vs-failure distinction: a playbook that never ran (the
+   batch died — machine never came back from a reboot, no build was produced,
+   the build summary was unreachable) must NOT be reported as a failed playbook.
+2. An artifact is written on EVERY exit path. `upload-artifact` runs with
+   `if-no-files-found: ignore`, so a crash makes the playbook vanish from the
+   aggregated report and the sticky comment undercounts — silently.
+3. The `results` rows keep the shape the website dashboard already reads
+   (website/src/lib/github-test-results.ts).
+
+Every case drives main() with a fixture summary.json; fetch() is stubbed, so
+nothing here touches the network or the OrchestrAI pipeline.
+
+Usage:
+    python3 .github/scripts/test_orchestrai_verdict.py
+"""
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "orchestrai_verdict", Path(__file__).with_name("orchestrai_verdict.py")
+)
+verdict = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(verdict)
+
+BUILD = "https://ci.example.invalid/job/x/1/"
+
+#: Sentinel for "fetch() hit a transport failure" (401, network, aborted build)
+#: as opposed to "fetch() returned an empty document".
+UNREACHABLE = object()
+
+# A batch where every playbook ran and passed.
+OLD_SCHEMA = {
+    "build_url": BUILD,
+    "rp_launch_url": "https://rp.example.invalid/launch/1",
+    "groups": {
+        "playbook-alpha": {"passed": 4, "failed": 0, "skipped": 1, "errors": 0,
+                           "status": "PASSED"},
+        "playbook-beta": {"passed": 2, "failed": 1, "skipped": 0, "errors": 0,
+                          "status": "FAILED"},
+    },
+}
+
+# The real-world failure: a batch of three, none of which ran.
+NEW_SCHEMA_NOT_RUN = {
+    "status": "INTERRUPTED",
+    "infrastructure_reason": "host did not return from reboot",
+    "expected_groups": ["playbook-alpha", "playbook-beta", "playbook-gamma"],
+    "groups": {
+        "playbook-alpha": {"passed": 0, "failed": 0, "skipped": 0, "errors": 0,
+                           "status": "NOT_RUN",
+                           "infrastructure_reason": "host did not return from reboot"},
+    },
+}
+
+# Keys deliberately removed from the artifact schema: the pipeline emits no
+# producer for any of them, and `jenkins_url` contradicts the repo's explicit
+# "the pipeline build URL is intentionally not shown" policy.
+REMOVED_KEYS = ("machine", "ticket", "last_phase", "jenkins_url")
+
+# The row schema the website dashboard already reads for this same filename.
+DASHBOARD_ROW_KEYS = ("test_id", "success", "skipped", "duration", "error_message")
+
+
+def run_verdict(summary, playbook, console="", platform="linux", build_url=BUILD,
+                patch=None):
+    """Run main() in a temp cwd against a fixture summary.json.
+
+    `summary`/`console` may be UNREACHABLE to simulate a fetch transport
+    failure (fetch() returns None) rather than an empty document.
+    `patch` is an optional {attribute: replacement} applied to the module, used
+    to inject an unexpected exception.
+
+    Returns (exit_code, artifact_dict_or_None, stdout).
+    """
+    raw = (UNREACHABLE if summary is UNREACHABLE
+           else json.dumps(summary) if summary is not None else "{}")
+
+    def fake_fetch(url, user, token):
+        value = console if url.endswith("consoleText") else raw
+        return None if value is UNREACHABLE else value
+
+    env = {"BUILD_URL": build_url, "PLAYBOOK_ID": playbook, "PLATFORM": platform,
+           "ORCHESTRAI_PIPELINE_USER": "u", "ORCHESTRAI_PIPELINE_TOKEN": "t"}
+    old_env = {k: os.environ.get(k) for k in list(env) + ["GITHUB_OUTPUT"]}
+    saved = {"fetch": verdict.fetch}
+    for name in (patch or {}):
+        saved[name] = getattr(verdict, name)
+    cwd = os.getcwd()
+    buf = io.StringIO()
+    try:
+        verdict.fetch = fake_fetch
+        for name, value in (patch or {}).items():
+            setattr(verdict, name, value)
+        os.environ.pop("GITHUB_OUTPUT", None)
+        os.environ.update(env)
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            with contextlib.redirect_stdout(buf):
+                try:
+                    verdict.main()
+                    code = 0
+                except SystemExit as e:
+                    code = e.code or 0
+            path = Path(tmp) / "test-results" / "summary.json"
+            doc = json.loads(path.read_text()) if path.exists() else None
+    finally:
+        os.chdir(cwd)
+        for name, value in saved.items():
+            setattr(verdict, name, value)
+        for k, v in old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    return code, doc, buf.getvalue()
+
+
+class TestPassingPath(unittest.TestCase):
+    def test_group_passed_exits_zero_with_populated_results(self):
+        code, doc, _ = run_verdict(OLD_SCHEMA, "alpha")
+        self.assertEqual(code, 0)
+        self.assertEqual(doc["outcome"], "PASSED")
+        self.assertEqual(doc["failed"], 0)
+        self.assertGreater(doc["passed"], 0)
+        self.assertIsNone(doc["infrastructure_reason"])
+        # The bug: `results` was always [], hiding the real outcome.
+        self.assertTrue(doc["results"], "results must never be empty")
+
+    def test_passing_artifact_carries_reportportal_url_and_outcome(self):
+        _, doc, _ = run_verdict(OLD_SCHEMA, "alpha")
+        for key in ("outcome", "infrastructure_reason", "reportportal_url"):
+            self.assertIn(key, doc)
+        self.assertEqual(doc["reportportal_url"], "https://rp.example.invalid/launch/1")
+
+    def test_producerless_fields_are_not_emitted(self):
+        # No pipeline key feeds these; emitting them made an unimplemented
+        # feature look implemented (and leaked the build URL).
+        _, doc, _ = run_verdict(OLD_SCHEMA, "alpha")
+        for key in REMOVED_KEYS:
+            self.assertNotIn(key, doc)
+
+
+class TestResultRowSchema(unittest.TestCase):
+    """`results` rows must be a superset of the row shape the website already
+    reads for this filename — not a second, incompatible shape."""
+
+    def test_passing_row_matches_dashboard_schema(self):
+        _, doc, _ = run_verdict(OLD_SCHEMA, "alpha")
+        row = doc["results"][0]
+        for key in DASHBOARD_ROW_KEYS:
+            self.assertIn(key, row)
+        self.assertEqual(row["test_id"], "alpha")
+        self.assertIs(row["success"], True)
+        self.assertIs(row["skipped"], False)
+        self.assertEqual(row["error_message"], "")
+        self.assertEqual(row["status"], "PASSED")
+
+    def test_failing_row_matches_dashboard_schema(self):
+        _, doc, _ = run_verdict(OLD_SCHEMA, "beta")
+        row = doc["results"][0]
+        for key in DASHBOARD_ROW_KEYS:
+            self.assertIn(key, row)
+        self.assertIs(row["success"], False)
+        self.assertIs(row["skipped"], False)
+        self.assertEqual(row["status"], "FAILED")
+        self.assertTrue(row["error_message"])
+
+    def test_not_run_row_matches_dashboard_schema(self):
+        _, doc, _ = run_verdict(NEW_SCHEMA_NOT_RUN, "alpha")
+        row = doc["results"][0]
+        for key in DASHBOARD_ROW_KEYS:
+            self.assertIn(key, row)
+        self.assertEqual(row["test_id"], "alpha")
+        self.assertIs(row["success"], False)
+        # A consumer that only knows success/skipped must not count a
+        # never-executed playbook as a red test.
+        self.assertIs(row["skipped"], True)
+        self.assertEqual(row["duration"], 0)
+        self.assertEqual(row["status"], "NOT_RUN")
+        self.assertIn("host did not return from reboot", row["error_message"])
+
+
+class TestFailingPath(unittest.TestCase):
+    def test_group_failed_exits_one(self):
+        code, doc, _ = run_verdict(OLD_SCHEMA, "beta")
+        self.assertEqual(code, 1)
+        self.assertEqual(doc["outcome"], "FAILED")
+        self.assertGreater(doc["failed"], 0)
+        self.assertTrue(doc["results"])
+
+    def test_old_schema_missing_group_still_fails(self):
+        # No expected_groups, no console result -> today's behaviour exactly.
+        code, doc, out = run_verdict(OLD_SCHEMA, "gamma")
+        self.assertEqual(code, 1)
+        self.assertEqual(doc["outcome"], "FAILED")
+        self.assertEqual(doc["failed"], 1)
+        self.assertIn("No verdict for gamma", out)
+
+    def test_old_schema_console_fallback_still_works(self):
+        console = ('Started suite "playbook-gamma #3" id=abc-123\n'
+                   'Finished item abc-123 -> PASSED\n')
+        code, doc, _ = run_verdict(OLD_SCHEMA, "gamma", console=console)
+        self.assertEqual(code, 0)
+        self.assertEqual(doc["outcome"], "PASSED")
+
+    def test_empty_summary_document_keeps_old_behaviour(self):
+        # A reachable but empty summary.json is a real (if unhelpful) answer,
+        # NOT a transport failure — it must stay a hard failure as today.
+        code, doc, _ = run_verdict({}, "alpha")
+        self.assertEqual(code, 1)
+        self.assertEqual(doc["outcome"], "FAILED")
+
+
+class TestInfrastructure(unittest.TestCase):
+    def test_not_run_group_exits_two_without_fabricating_a_failure(self):
+        code, doc, out = run_verdict(NEW_SCHEMA_NOT_RUN, "alpha")
+        self.assertEqual(code, 2)
+        self.assertEqual(doc["outcome"], "NOT_RUN")
+        self.assertEqual(doc["failed"], 0, "NOT_RUN must not fabricate a failure")
+        self.assertEqual(doc["infrastructure_reason"], "host did not return from reboot")
+        self.assertTrue(doc["results"])
+        self.assertEqual(doc["results"][0]["status"], "NOT_RUN")
+        self.assertIn("host did not return from reboot", doc["results"][0]["error_message"])
+        self.assertIn("::warning::", out)
+
+    def test_group_missing_from_new_schema_is_infrastructure_not_failure(self):
+        code, doc, _ = run_verdict(NEW_SCHEMA_NOT_RUN, "gamma")
+        self.assertEqual(code, 2, "a planned-but-absent group is not a test failure")
+        self.assertEqual(doc["outcome"], "NOT_RUN")
+        self.assertEqual(doc["failed"], 0)
+        self.assertTrue(doc["infrastructure_reason"])
+        self.assertTrue(doc["results"])
+
+    def test_interrupted_group_exits_two(self):
+        summary = {"expected_groups": ["playbook-alpha"],
+                   "groups": {"playbook-alpha": {
+                       "passed": 0, "failed": 0, "skipped": 0, "errors": 0,
+                       "status": "INTERRUPTED",
+                       "infrastructure_reason": "machine acquisition timed out"}}}
+        code, doc, _ = run_verdict(summary, "alpha")
+        self.assertEqual(code, 2)
+        self.assertEqual(doc["outcome"], "INTERRUPTED")
+        self.assertEqual(doc["failed"], 0)
+        self.assertEqual(doc["infrastructure_reason"], "machine acquisition timed out")
+
+    def test_missing_build_url_is_infrastructure_not_a_failure(self):
+        # This is the 79-job shape: no build means NO playbook in the batch
+        # ran, so it must not fan out into N alleged test failures.
+        code, doc, out = run_verdict(OLD_SCHEMA, "alpha", build_url="")
+        self.assertEqual(code, 2)
+        self.assertEqual(doc["outcome"], "NOT_RUN")
+        self.assertEqual(doc["failed"], 0)
+        self.assertEqual(doc["total_tests"], 0)
+        self.assertIn("no OrchestrAI build was produced", doc["infrastructure_reason"])
+        self.assertTrue(doc["results"])
+        self.assertIn("::warning::", out)
+
+    def test_unreachable_build_summary_is_infrastructure_not_a_failure(self):
+        # 401 / network / aborted build: fetch() returns None, which must be
+        # distinguishable from an empty document.
+        code, doc, out = run_verdict(UNREACHABLE, "alpha", console=UNREACHABLE)
+        self.assertEqual(code, 2)
+        self.assertEqual(doc["outcome"], "NOT_RUN")
+        self.assertEqual(doc["failed"], 0)
+        self.assertIn("could not retrieve the build summary",
+                      doc["infrastructure_reason"])
+        self.assertIn("::warning::", out)
+
+    def test_unreachable_summary_still_defers_to_a_readable_console(self):
+        console = ('Started suite "playbook-alpha #1" id=abc-123\n'
+                   'Finished item abc-123 -> PASSED\n')
+        code, doc, _ = run_verdict(UNREACHABLE, "alpha", console=console)
+        self.assertEqual(code, 0)
+        self.assertEqual(doc["outcome"], "PASSED")
+
+
+class TestNeverCrashWithoutAnArtifact(unittest.TestCase):
+    """`if-no-files-found: ignore` turns a crash into a silent undercount."""
+
+    def test_non_dict_groups_writes_an_artifact_and_exits_two(self):
+        code, doc, out = run_verdict({"groups": [1, 2]}, "alpha")
+        self.assertIsNotNone(doc, "an artifact must be written even on bad input")
+        self.assertEqual(code, 2)
+        self.assertEqual(doc["outcome"], "INTERRUPTED")
+        self.assertEqual(doc["failed"], 0)
+        self.assertTrue(doc["infrastructure_reason"])
+        self.assertNotIn("Traceback", out)
+
+    def test_non_dict_groups_variants_all_write_an_artifact(self):
+        for bad in ([1, 2], "groups", 7, True):
+            _, doc, _ = run_verdict({"groups": bad}, "alpha")
+            self.assertIsNotNone(doc, f"no artifact written for groups={bad!r}")
+
+    def test_unexpected_exception_still_writes_an_artifact(self):
+        def boom(_grp):
+            raise RuntimeError("kaboom")
+
+        code, doc, out = run_verdict(OLD_SCHEMA, "alpha",
+                                     patch={"status_from_group": boom})
+        self.assertIsNotNone(doc, "an artifact must survive an unexpected crash")
+        self.assertEqual(code, 2)
+        self.assertEqual(doc["outcome"], "INTERRUPTED")
+        self.assertEqual(doc["failed"], 0)
+        self.assertIn("kaboom", doc["infrastructure_reason"])
+        self.assertIn("::warning::", out)
+
+
+class TestZeroCountsNeverPass(unittest.TestCase):
+    def test_group_claiming_passed_with_zero_counts_is_not_passed(self):
+        summary = {"groups": {"playbook-alpha": {
+            "passed": 0, "failed": 0, "skipped": 0, "errors": 0, "status": "PASSED"}}}
+        code, doc, _ = run_verdict(summary, "alpha")
+        self.assertNotEqual(doc["outcome"], "PASSED")
+        self.assertNotEqual(code, 0)
+        self.assertEqual(code, 2)
+
+    def test_no_artifact_ever_has_passed_with_zero_tests(self):
+        for summary, pb in ((OLD_SCHEMA, "alpha"), (OLD_SCHEMA, "beta"),
+                            (NEW_SCHEMA_NOT_RUN, "alpha"),
+                            (NEW_SCHEMA_NOT_RUN, "gamma")):
+            _, doc, _ = run_verdict(summary, pb)
+            if doc["outcome"] == "PASSED":
+                self.assertGreater(doc["total_tests"], 0)
+
+
+class TestExitCodeMap(unittest.TestCase):
+    """STRUCTURAL: asserts the helper exists and maps as the contract says.
+    (Against the pre-change script this errors rather than fails — the helper
+    did not exist. The behavioural coverage is in the classes above.)"""
+
+    def test_exit_code_for(self):
+        self.assertEqual(verdict.exit_code_for("PASSED"), 0)
+        self.assertEqual(verdict.exit_code_for("FAILED"), 1)
+        self.assertEqual(verdict.exit_code_for("NOT_RUN"), 2)
+        self.assertEqual(verdict.exit_code_for("INTERRUPTED"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/orchestrai-pr-command.yml
+++ b/.github/workflows/orchestrai-pr-command.yml
@@ -213,7 +213,26 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
           ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
-        run: python3 .github/scripts/orchestrai_verdict.py
+        # KEEP IN SYNC with the identical step in test-playbooks-orchestrai.yml
+        # ("Resolve per-playbook verdict"). Deliberately duplicated rather than
+        # factored into .github/actions/: this workflow runs from the DEFAULT
+        # branch but `uses: ./...` resolves against the PR checkout, so a local
+        # composite action would hard-fail `!orc` on every PR branch that
+        # predates it.
+        #
+        # Exit codes: 0 PASSED, 1 FAILED (real test failure), 2 NOT_RUN/
+        # INTERRUPTED (the batch never produced results for this playbook).
+        # GitHub has no neutral step result, so 2 still fails the job — but it is
+        # annotated as infrastructure and the artifact records outcome=NOT_RUN,
+        # so the aggregated PR comment counts it separately from test failures.
+        run: |
+          rc=0
+          python3 .github/scripts/orchestrai_verdict.py || rc=$?
+          echo "verdict_rc=${rc}" >> "$GITHUB_OUTPUT"
+          if [ "$rc" = "2" ]; then
+            echo "::warning::${PLAYBOOK_ID} (${PLATFORM}) did not run — OrchestrAI infrastructure issue, not a test failure"
+          fi
+          exit "$rc"
 
       - name: Upload test artifacts
         if: always()
@@ -227,10 +246,31 @@ jobs:
         if: always()
         env:
           RP_URL: ${{ steps.results.outputs.rp_url }}
+        # KEEP IN SYNC with the identical step in test-playbooks-orchestrai.yml
+        # ("Test summary"). See the sync note on the verdict step above.
         run: |
+          # NOT_RUN/INTERRUPTED is infrastructure, not a test failure — say so in
+          # the job summary instead of letting it read as a failed playbook.
+          INFRA_NOTE=$(python3 - <<'PY'
+          import json
+          try:
+              d = json.load(open("test-results/summary.json"))
+          except Exception:
+              d = {}
+          outcome = (d.get("outcome") or "").upper()
+          if outcome in ("NOT_RUN", "INTERRUPTED"):
+              reason = d.get("infrastructure_reason") or "reason not reported by the pipeline"
+              print(f"> ⚠️ **{outcome}** — this playbook produced no test results. "
+                    f"Infrastructure: {reason}")
+          PY
+          )
           {
             echo "### \`${{ matrix.playbook }}\` (${{ matrix.platform }}/${{ matrix.arch }})"
             echo ""
+            if [ -n "${INFRA_NOTE}" ]; then
+              echo "${INFRA_NOTE}"
+              echo ""
+            fi
             # ReportPortal (test results) link only; the pipeline build URL is
             # intentionally not shown. Populated even when the verdict fails.
             if [ -n "${RP_URL}" ]; then

--- a/.github/workflows/test-playbooks-orchestrai.yml
+++ b/.github/workflows/test-playbooks-orchestrai.yml
@@ -241,7 +241,24 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           ORCHESTRAI_PIPELINE_USER: ${{ secrets.ORCHESTRAI_PIPELINE_USER }}
           ORCHESTRAI_PIPELINE_TOKEN: ${{ secrets.ORCHESTRAI_PIPELINE_TOKEN }}
-        run: python3 .github/scripts/orchestrai_verdict.py
+        # KEEP IN SYNC with the identical step in orchestrai-pr-command.yml
+        # ("Resolve per-playbook verdict"), which is where the user-facing !orc
+        # sticky comment comes from. Deliberately duplicated rather than
+        # factored into .github/actions/ — see the rationale on that copy.
+        #
+        # Exit codes: 0 PASSED, 1 FAILED (real test failure), 2 NOT_RUN/
+        # INTERRUPTED (the batch never produced results for this playbook).
+        # GitHub has no neutral step result, so 2 still fails the job — but it is
+        # annotated as infrastructure and the artifact records outcome=NOT_RUN,
+        # so the aggregated PR report counts it separately from test failures.
+        run: |
+          rc=0
+          python3 .github/scripts/orchestrai_verdict.py || rc=$?
+          echo "verdict_rc=${rc}" >> "$GITHUB_OUTPUT"
+          if [ "$rc" = "2" ]; then
+            echo "::warning::${PLAYBOOK_ID} (${PLATFORM}) did not run — OrchestrAI infrastructure issue, not a test failure"
+          fi
+          exit "$rc"
 
       - name: Upload test artifacts
         if: always()
@@ -255,10 +272,31 @@ jobs:
         if: always()
         env:
           RP_URL: ${{ steps.results.outputs.rp_url }}
+        # KEEP IN SYNC with the identical step in orchestrai-pr-command.yml
+        # ("Test summary"). See the sync note on the verdict step above.
         run: |
+          # NOT_RUN/INTERRUPTED is infrastructure, not a test failure — say so in
+          # the job summary instead of letting it read as a failed playbook.
+          INFRA_NOTE=$(python3 - <<'PY'
+          import json
+          try:
+              d = json.load(open("test-results/summary.json"))
+          except Exception:
+              d = {}
+          outcome = (d.get("outcome") or "").upper()
+          if outcome in ("NOT_RUN", "INTERRUPTED"):
+              reason = d.get("infrastructure_reason") or "reason not reported by the pipeline"
+              print(f"> ⚠️ **{outcome}** — this playbook produced no test results. "
+                    f"Infrastructure: {reason}")
+          PY
+          )
           {
             echo "### \`${{ matrix.playbook }}\` (${{ matrix.platform }}/${{ matrix.arch }})"
             echo ""
+            if [ -n "${INFRA_NOTE}" ]; then
+              echo "${INFRA_NOTE}"
+              echo ""
+            fi
             # Link to ReportPortal (test results) only. The pipeline build URL is
             # intentionally not shown here.
             if [ -n "${RP_URL}" ]; then

--- a/.github/workflows/test-playbooks.yml
+++ b/.github/workflows/test-playbooks.yml
@@ -132,6 +132,10 @@ jobs:
         run: python3 .github/scripts/test_build_test_matrix.py
       - name: Run playbook-test extractor tests
         run: python3 .github/scripts/test_run_playbook_tests.py
+      - name: Run OrchestrAI verdict tests
+        run: python3 .github/scripts/test_orchestrai_verdict.py
+      - name: Run OrchestrAI report tests
+        run: python3 .github/scripts/test_orchestrai_report.py
 
   test-playbooks:
     name: "Test ${{ matrix.playbook }} (${{ matrix.platform }}/${{ matrix.arch }})${{ matrix.runner_label != '' && format(' @{0}', matrix.runner_label) || '' }}${{ matrix.required && ' ✦' || '' }}"


### PR DESCRIPTION
## The bug

`orchestrai_verdict.py` found no `groups["playbook-<id>"]`, called `write_summary(False)` and exited 1 — converting each **missing** verdict into an **alleged test failure**. One failed reboot produced 13 red playbooks that never executed, while the pipeline reported PASSED. **79+ jobs.**

## What changes

- NOT_RUN / INTERRUPTED are understood. Exit **2** for infrastructure (0 = pass, 1 = real test failure), `failed` stays **0**, and the annotation is a `::warning::` that says it isn't a test failure.
- `orchestrai_report.py` renders three categories and states the shared reason **once**, not 13 times.
- **`results[]` was always `[]`** — which is exactly why the artifacts hid the real outcome. Now populated, using a **superset** of the row shape the website dashboard already reads (`{test_id, success, skipped, duration, error_message}`) plus `status`, rather than inventing a second shape for the same filename.

## Infrastructure that never produced a build

Empty `BUILD_URL` and `fetch()` transport failure now both yield exit 2 / NOT_RUN instead of a test failure. The `BUILD_URL` case fans out to *every* playbook in a batch — it is the 79-job shape. `fetch()` now distinguishes transport failure (`None`) from a legitimately empty document, so a 401 or an aborted build is no longer indistinguishable from "the batch had no results".

## Silent undercount fixed

A non-dict `groups` value raised at the `.get()` and wrote **no artifact**. With `if-no-files-found: ignore`, the playbook then vanished from the report — the comment said "12 not run" when 13 were planned. Any unexpected exception now still writes an artifact before exiting. A silent undercount is worse than a wrong count.

## The workflow the first pass missed

`orchestrai-pr-command.yml` is the **only** place `orchestrai_report.py` runs, and it's the `!orc` surface this ticket is about — but the first pass updated only `test-playbooks-orchestrai.yml`, which has no report job. The new three-category rendering was unreachable where anyone would actually see it. Both are updated now.

⚠️ `issue_comment` workflows run from the **default branch**, so the `!orc` half only takes effect once this is merged — testing it on this PR branch will not exercise it.

## Dropped as dead code

`machine` / `ticket` / `last_phase` / `jenkins_url` and their key-alias tables. The pipeline emits none of those keys, so they were provably always `null` — and a test asserting the passthrough made coverage look green for a feature with no producer. `jenkins_url` additionally contradicted this repo's explicit *"the pipeline build URL is intentionally not shown here"* policy.

If `machine` is wanted it must be emitted by the **pipeline**, which actually knows it. Guessing 13 key names on the reader side was the wrong half of the contract to solve it in.

## Verification — against real pipeline output, not fixtures

Fed the actual `summary.json` produced by ucicd-pipeline#216 for a 13-playbook failed-reboot batch:

```
batch status         : INTERRUPTED
group states         : {'NOT_RUN': 13}
verdict exit codes   : {2: 13}          (2 = infrastructure)
alleged test failures: 0
```

Aggregated comment, with genuine failures mixed in to prove the categories separate:

```
### OrchestrAI results — ❌ 2 failed, ⚠️ 3 not run (infrastructure), ✅ 1 passed
| `pb1` | linux | halo | ⚠️ not run |
> ⚠️ 3 playbooks did not run — infrastructure: batch did not complete; 13 of 13 playbooks never ran
```

| Suite | With change | Against original |
|---|---|---|
| `test_orchestrai_verdict.py` | **22 OK** | 5 failures, 16 errors |
| `test_orchestrai_report.py` | **13 OK** | 6 failures, 1 error |
| `test_run_playbook_tests.py` | 2 OK | 2 OK (no collateral) |

Both workflows `yaml.safe_load`-clean; the modified `run:` blocks were extracted and executed in real bash to confirm rc 0/1/2 map to step exits correctly.

Backward compatible both directions: an old `summary.json` takes the old path exactly, and the console fallback is untouched.

## Follow-up worth knowing about

The reason string will always be the generic `"batch did not complete; N of M playbooks never ran"` until a producer is wired into the pipeline's acquisition/reboot path — nothing records *why* a batch died today. Details in ucicd-pipeline#216.
