### PR TITLE
Bugfix RCCL cluster stability with Ray backend

### DIFF
--- a/playbooks/supplemental/clustering-rccl/README.md
+++ b/playbooks/supplemental/clustering-rccl/README.md
@@ -148,6 +148,7 @@ sudo podman run -it --name vllm_cluster --replace --pull missing --network=host 
 vLLM uses Ray to orchestrate the cluster and RCCL to handle GPU-to-GPU communication across nodes. One machine acts as the **head node** (Machine 1), coordinating inference. The other joins as a **worker node** (Machine 2), contributing its GPU memory and compute.
 
 > **Note**: Ray is an optional dependency for vLLM and is only available from within the preconfigured Podman container.
+<p> In configurations where the system RAM is low, there is a risk that Ray's memory guard will kill the Ray workers because they are allocating memory higher than the threshold allowed by Ray, and the logs will output ```ray.exceptions.OutOfMemoryError: 1 worker(s) were killed due to the node running low on memory.``` To prevent the Ray workers from being killed, export ```RAY_memory_monitor_refresh_ms=0``` on each of the machines before starting and joining the Ray cluster.
 
 At launch, vLLM shards the model across both nodes using tensor parallelism. Once loaded, inference proceeds as if running on a single accelerator.
 

--- a/playbooks/supplemental/clustering-rccl/README.md
+++ b/playbooks/supplemental/clustering-rccl/README.md
@@ -147,8 +147,9 @@ sudo podman run -it --name vllm_cluster --replace --pull missing --network=host 
 
 vLLM uses Ray to orchestrate the cluster and RCCL to handle GPU-to-GPU communication across nodes. One machine acts as the **head node** (Machine 1), coordinating inference. The other joins as a **worker node** (Machine 2), contributing its GPU memory and compute.
 
-> **Note**: Ray is an optional dependency for vLLM and is only available from within the preconfigured Podman container.
-<p> In configurations where the system RAM is low, there is a risk that Ray's memory guard will kill the Ray workers because they are allocating memory higher than the threshold allowed by Ray, and the logs will output ```ray.exceptions.OutOfMemoryError: 1 worker(s) were killed due to the node running low on memory.``` To prevent the Ray workers from being killed, export ```RAY_memory_monitor_refresh_ms=0``` on each of the machines before starting and joining the Ray cluster.
+> **Note**: Ray is an optional dependency for vLLM and is only available from within the preconfigured Podman container. <p> In configurations where the system RAM is low, there is a risk that Ray's memory guard will kill the Ray workers because they are allocating memory higher than the threshold allowed by Ray, and the logs will output 
+<br>```ray.exceptions.OutOfMemoryError: 1 worker(s) were killed due to the node running low on memory.```<br>
+To prevent the Ray workers from being killed, export ```RAY_memory_monitor_refresh_ms=0``` on each of the machines before starting and joining the Ray cluster.
 
 At launch, vLLM shards the model across both nodes using tensor parallelism. Once loaded, inference proceeds as if running on a single accelerator.
 
@@ -157,6 +158,7 @@ At launch, vLLM shards the model across both nodes using tensor parallelism. Onc
 On Machine 1, start the Ray head node to initialize the cluster:
 
 ```bash
+export RAY_memory_monitor_refresh_ms=0
 ray start --head --port=6379 --node-ip-address=<MACHINE_1_IP> --num-gpus=1
 ```
 
@@ -167,6 +169,7 @@ ray start --head --port=6379 --node-ip-address=<MACHINE_1_IP> --num-gpus=1
 On Machine 2, connect to the head node to form the cluster:
 
 ```bash
+export RAY_memory_monitor_refresh_ms=0
 ray start --address=<MACHINE_1_IP>:6379 --node-ip-address=<MACHINE_2_IP> --num-gpus=1
 ```
 


### PR DESCRIPTION
Addressing https://github.com/amd/playbooks/issues/771, machines will have Ray workers killed when exceeding Ray's memory usage threshold during vLLM engine startup. This will mitigate those situations when the model weights is close to the VRAM capacity and the system RAM is low.
The issue is tracked internally at https://ontrack.amd.com/browse/TIC-181758 and https://ontrack.amd.com/browse/TIC-180544.
Tested on setup with 2 StrixHalo AI boxes, and setup with 2 GorgonHalo boxes.