### PR TITLE
feat(ci): validate & self-heal playbook prerequisites on runners before tests

### DIFF
--- a/.github/scripts/prereq_validate.py
+++ b/.github/scripts/prereq_validate.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Playbook Prerequisite Validator
+===============================
+
+Runs on a CI runner *before* ``run_playbook_tests.py`` to make sure the
+prerequisites a playbook needs are actually present on the machine -- and to
+**self-heal** the runner by installing anything that is missing.
+
+For each ``@require:<dep>`` a playbook declares (scoped to the active
+``@os:``/``@device:`` blocks), this reads a ``validate`` and optional
+``install`` command from ``playbooks/dependencies/registry.json`` and runs a
+validate -> (if missing) install -> re-validate loop:
+
+    validate passes                -> OK                 (provisioned; no install)
+    validate fails, install fixes  -> INSTALLED          (self-healed; job continues)
+    validate fails, install fails  -> FAILED             (hard fail)
+    validate fails, no install     -> MISSING_NO_INSTALL (hard fail)
+    no validate for this platform  -> unchecked          (nothing to verify)
+
+Exit code is non-zero only when a dependency ends FAILED or MISSING_NO_INSTALL.
+A per-dependency status report is always written to
+``test-results/<playbook>/prereq.json`` so a self-heal (or a hard fail) is
+visible in the uploaded CI artifacts and is clearly distinct from an ordinary
+test failure.
+
+Usage:
+    python prereq_validate.py --playbook <id> --platform linux|windows [--device <device>]
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+VALID_DEVICES = {"halo", "stx", "krk", "rx7900xt", "rx9070xt", "r9700"}
+# halo_box is a valid @device: scope in READMEs even though it is not a CI
+# --device value, so accept it when matching require scopes.
+KNOWN_DEVICE_SCOPES = VALID_DEVICES | {"halo_box"}
+
+
+def find_playbook_path(playbook_id: str, repo_root: Path) -> Optional[Path]:
+    """Find the playbook directory by ID (mirrors run_playbook_tests.py)."""
+    for category in ["core", "supplemental"]:
+        playbook_path = repo_root / "playbooks" / category / playbook_id
+        if playbook_path.exists() and (playbook_path / "README.md").exists():
+            return playbook_path
+    return None
+
+
+def extract_scoped_requires(
+    content: str, platform: str, device: Optional[str]
+) -> list[str]:
+    """Return the ordered, de-duplicated list of @require dep-ids that apply
+    to the active platform/device.
+
+    @require tags may be wrapped in ``@os:<p>``/``@device:<d,...>`` blocks. A
+    require is in scope when the current @os block (if any) matches ``platform``
+    AND the current @device block (if any) matches ``device``. A require with no
+    enclosing block of a given kind is unscoped for that kind (applies to all).
+    """
+    os_re = re.compile(r"<!--\s*@os:([\w,]+)\s*-->")
+    os_end_re = re.compile(r"<!--\s*@os:end\s*-->")
+    dev_re = re.compile(r"<!--\s*@device:([\w,]+)\s*-->")
+    dev_end_re = re.compile(r"<!--\s*@device:end\s*-->")
+    req_re = re.compile(r"<!--\s*@require:([a-z0-9\-,]+)\s*-->")
+
+    cur_os: Optional[set[str]] = None
+    cur_dev: Optional[set[str]] = None
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    for line in content.splitlines():
+        # End tags must be checked before the open patterns: the open regex
+        # ``@os:([\w,]+)`` would otherwise match ``@os:end`` as a block named
+        # "end".
+        if os_end_re.search(line):
+            cur_os = None
+            continue
+        m = os_re.search(line)
+        if m:
+            cur_os = {p.strip() for p in m.group(1).split(",") if p.strip()}
+            continue
+        if dev_end_re.search(line):
+            cur_dev = None
+            continue
+        m = dev_re.search(line)
+        if m:
+            cur_dev = {d.strip() for d in m.group(1).split(",") if d.strip()}
+            continue
+
+        m = req_re.search(line)
+        if not m:
+            continue
+
+        # OS scope: if an @os block is active and doesn't include our platform, skip.
+        if cur_os is not None and platform not in cur_os:
+            continue
+        # Device scope: if a @device block is active, only apply when it names a
+        # known device scope AND (we have no --device, or our device is listed).
+        if cur_dev is not None:
+            device_scopes = cur_dev & KNOWN_DEVICE_SCOPES
+            if device_scopes and device is not None and device not in cur_dev:
+                continue
+
+        for dep_id in (d.strip() for d in m.group(1).split(",")):
+            if dep_id and dep_id not in seen:
+                seen.add(dep_id)
+                ordered.append(dep_id)
+
+    return ordered
+
+
+def _run(cmd: str, platform: str, timeout: int) -> int:
+    """Run a shell command and return its exit code (best-effort)."""
+    shell_exe = None
+    if platform == "windows":
+        # Use PowerShell so validate/install strings match the doc conventions.
+        args = ["powershell", "-NoProfile", "-Command", cmd]
+    else:
+        args = ["bash", "-c", cmd]
+    try:
+        proc = subprocess.run(
+            args,
+            timeout=timeout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        if proc.stdout:
+            # Surface command output for CI logs, but keep it bounded.
+            sys.stdout.write(proc.stdout[-4000:])
+            sys.stdout.flush()
+        return proc.returncode
+    except subprocess.TimeoutExpired:
+        print(f"  (timed out after {timeout}s)")
+        return 124
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"  (failed to launch: {exc})")
+        return 1
+
+
+def _validate(spec: dict, platform: str) -> bool:
+    v = (spec.get("validate") or {}).get(platform)
+    if not v:
+        return False
+    rc = _run(v["cmd"], platform, v.get("timeout", 60))
+    return rc == v.get("expect_rc", 0)
+
+
+def check_dependency(dep_id: str, spec: dict, platform: str) -> dict:
+    """Run the validate -> install -> re-validate loop for one dependency."""
+    result = {"dep": dep_id, "status": "unchecked", "install_ran": False}
+
+    validate = (spec.get("validate") or {}).get(platform)
+    if not validate:
+        print(f"- {dep_id}: no validate command for {platform} -> unchecked")
+        return result
+
+    print(f"- {dep_id}: validating ...")
+    if _validate(spec, platform):
+        result["status"] = "OK"
+        print(f"  OK: {dep_id} present")
+        return result
+
+    # ---- validate miss: attempt self-heal ----
+    install = (spec.get("install") or {}).get(platform)
+    if not install:
+        # Optional deps warn instead of hard-failing: the runner may have the
+        # prerequisite provisioned in a way our check can't see (e.g. an LM
+        # Studio model whose CLI needs a running backend), so we record the
+        # miss for diagnostics but let the job proceed to its tests.
+        if spec.get("optional"):
+            result["status"] = "MISSING_OPTIONAL"
+            print(f"  WARN: {dep_id} not detected and no install recipe; continuing (optional)")
+        else:
+            result["status"] = "MISSING_NO_INSTALL"
+            print(f"  MISSING: {dep_id} not present and no install recipe for {platform}")
+        return result
+
+    print(f"  MISSING: {dep_id} -> installing (this may take a while) ...")
+    result["install_ran"] = True
+    install_rc = _run(install["cmd"], platform, install.get("timeout", 1800))
+    result["install_rc"] = install_rc
+
+    print(f"  re-validating {dep_id} ...")
+    if _validate(spec, platform):
+        result["status"] = "INSTALLED"
+        print(f"  INSTALLED: {dep_id} now present")
+    else:
+        result["status"] = "FAILED"
+        print(f"  FAILED: {dep_id} still missing after install")
+    return result
+
+
+def validate_prereqs(playbook_id: str, platform: str, device: Optional[str]) -> bool:
+    repo_root = Path(__file__).parent.parent.parent
+    dependencies_root = repo_root / "playbooks" / "dependencies"
+    registry_path = dependencies_root / "registry.json"
+
+    playbook_path = find_playbook_path(playbook_id, repo_root)
+    if not playbook_path:
+        print(f"Error: playbook '{playbook_id}' not found")
+        return False
+
+    try:
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"Error: could not read registry.json: {exc}")
+        return False
+    deps_map = registry.get("dependencies", {})
+
+    content = (playbook_path / "README.md").read_text(encoding="utf-8")
+    required = extract_scoped_requires(content, platform, device)
+
+    scope = f"{platform}/{device}" if device else platform
+    print(f"Prerequisite validation for {playbook_id} ({scope})")
+    if not required:
+        print("No @require dependencies in scope; nothing to validate.")
+    print(f"In-scope requires: {', '.join(required) if required else '(none)'}\n")
+
+    results = []
+    for dep_id in required:
+        spec = deps_map.get(dep_id)
+        if not spec:
+            print(f"- {dep_id}: not found in registry -> unchecked")
+            results.append({"dep": dep_id, "status": "unchecked", "install_ran": False})
+            continue
+        results.append(check_dependency(dep_id, spec, platform))
+
+    # Always write a report artifact.
+    results_dir = repo_root / "test-results" / playbook_id
+    results_dir.mkdir(parents=True, exist_ok=True)
+    report = {
+        "playbook_id": playbook_id,
+        "platform": platform,
+        "device": device,
+        "required": required,
+        "results": results,
+    }
+    (results_dir / "prereq.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    unresolved = [r for r in results if r["status"] in ("FAILED", "MISSING_NO_INSTALL")]
+    healed = [r for r in results if r["status"] == "INSTALLED"]
+
+    print()
+    if healed:
+        names = ", ".join(r["dep"] for r in healed)
+        print(f"Self-healed on runner: {names}")
+
+    if unresolved:
+        print("=" * 60)
+        print(f"PREREQ UNRESOLVED - {playbook_id} ({scope})")
+        for r in unresolved:
+            why = (
+                "auto-install did not resolve it"
+                if r["status"] == "FAILED"
+                else "auto-install is not available"
+            )
+            print(f"  {r['dep']}: missing and {why}.")
+        print("  -> runner-provisioning issue, NOT a playbook bug.")
+        print("=" * 60)
+        return False
+
+    print(f"All prerequisites satisfied for {playbook_id} ({scope}).")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate & provision playbook prerequisites")
+    parser.add_argument("--playbook", required=True, help="Playbook ID")
+    parser.add_argument(
+        "--platform", required=True, choices=["windows", "linux"], help="Target platform"
+    )
+    parser.add_argument(
+        "--device",
+        choices=sorted(VALID_DEVICES),
+        default=None,
+        help="Target device (filters @device: blocks)",
+    )
+    args = parser.parse_args()
+
+    ok = validate_prereqs(args.playbook, args.platform, args.device)
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_prereq_validate.py
+++ b/.github/scripts/test_prereq_validate.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Regression tests for prereq_validate.py.
+
+Covers:
+- @require scoping across @os:/@device: blocks (including the @os:end vs
+  @os:<name> parsing hazard that would otherwise swallow requires after an
+  end tag).
+- The validate -> install -> re-validate loop's five outcomes: OK, INSTALLED,
+  FAILED, MISSING_NO_INSTALL, unchecked.
+"""
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "prereq_validate", Path(__file__).with_name("prereq_validate.py")
+)
+pv = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(pv)
+
+# Mirrors the shape of n8n-automation-gpt-oss: an @os-scoped require, a
+# device-scoped model require, and requires that follow an @os:end tag.
+FIXTURE = """\
+<!-- @device:rx7900xt,rx9070xt,r9700 -->
+<!-- @require:driver -->
+<!-- @device:end -->
+
+<!-- @os:windows -->
+<!-- @require:lemonade,nodejs -->
+<!-- @os:end -->
+
+<!-- @os:linux -->
+<!-- @require:lemonade,podman -->
+<!-- @os:end -->
+
+<!-- @device:halo,halo_box -->
+<!-- @require:lemonade-models-gpt-oss-120b -->
+<!-- @device:end -->
+"""
+
+
+class ScopingTests(unittest.TestCase):
+    def test_linux_halo_includes_model_after_os_end(self):
+        # The model require sits after an @os:end tag; it must not be swallowed.
+        deps = pv.extract_scoped_requires(FIXTURE, "linux", "halo")
+        self.assertEqual(deps, ["lemonade", "podman", "lemonade-models-gpt-oss-120b"])
+
+    def test_windows_halo_uses_windows_os_block(self):
+        deps = pv.extract_scoped_requires(FIXTURE, "windows", "halo")
+        self.assertEqual(deps, ["lemonade", "nodejs", "lemonade-models-gpt-oss-120b"])
+
+    def test_non_halo_device_excludes_model(self):
+        deps = pv.extract_scoped_requires(FIXTURE, "linux", "stx")
+        self.assertNotIn("lemonade-models-gpt-oss-120b", deps)
+        self.assertIn("podman", deps)
+
+    def test_driver_only_for_its_devices(self):
+        self.assertIn("driver", pv.extract_scoped_requires(FIXTURE, "linux", "r9700"))
+        self.assertNotIn("driver", pv.extract_scoped_requires(FIXTURE, "linux", "halo"))
+
+
+class LoopTests(unittest.TestCase):
+    def test_ok_when_validate_passes(self):
+        spec = {"validate": {"linux": {"cmd": "true", "expect_rc": 0}}}
+        r = pv.check_dependency("d", spec, "linux")
+        self.assertEqual(r["status"], "OK")
+        self.assertFalse(r["install_ran"])
+
+    def test_installed_when_install_heals(self):
+        flag = tempfile.mktemp()
+        try:
+            spec = {
+                "validate": {"linux": {"cmd": f"test -f {flag}", "expect_rc": 0}},
+                "install": {"linux": {"cmd": f"touch {flag}", "timeout": 5}},
+            }
+            r = pv.check_dependency("d", spec, "linux")
+            self.assertEqual(r["status"], "INSTALLED")
+            self.assertTrue(r["install_ran"])
+        finally:
+            if os.path.exists(flag):
+                os.remove(flag)
+
+    def test_failed_when_install_does_not_heal(self):
+        spec = {
+            "validate": {"linux": {"cmd": "false", "expect_rc": 0}},
+            "install": {"linux": {"cmd": "true", "timeout": 5}},
+        }
+        self.assertEqual(pv.check_dependency("d", spec, "linux")["status"], "FAILED")
+
+    def test_missing_no_install(self):
+        spec = {"validate": {"linux": {"cmd": "false", "expect_rc": 0}}}
+        self.assertEqual(
+            pv.check_dependency("d", spec, "linux")["status"], "MISSING_NO_INSTALL"
+        )
+
+    def test_optional_miss_warns_not_fails(self):
+        # An optional dep whose validate fails and has no install must not be a
+        # hard failure (status not in the unresolved set).
+        spec = {"optional": True, "validate": {"linux": {"cmd": "false", "expect_rc": 0}}}
+        self.assertEqual(
+            pv.check_dependency("d", spec, "linux")["status"], "MISSING_OPTIONAL"
+        )
+
+    def test_unchecked_when_no_validate_for_platform(self):
+        spec = {"validate": {"windows": {"cmd": "true", "expect_rc": 0}}}
+        self.assertEqual(pv.check_dependency("d", spec, "linux")["status"], "unchecked")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_prereq_validate.py
+++ b/.github/scripts/test_prereq_validate.py
@@ -75,8 +75,10 @@ class LoopTests(unittest.TestCase):
         self.assertFalse(r["install_ran"])
 
     def test_installed_when_install_heals(self):
-        flag = tempfile.mktemp()
-        try:
+        # Use a private temp dir and a not-yet-created path inside it, so the
+        # first validate fails and the install `touch` is what makes it pass.
+        with tempfile.TemporaryDirectory() as tmp:
+            flag = os.path.join(tmp, "heal-flag")
             spec = {
                 "validate": {"linux": {"cmd": f"test -f {flag}", "expect_rc": 0}},
                 "install": {"linux": {"cmd": f"touch {flag}", "timeout": 5}},
@@ -84,9 +86,6 @@ class LoopTests(unittest.TestCase):
             r = pv.check_dependency("d", spec, "linux")
             self.assertEqual(r["status"], "INSTALLED")
             self.assertTrue(r["install_ran"])
-        finally:
-            if os.path.exists(flag):
-                os.remove(flag)
 
     def test_failed_when_install_does_not_heal(self):
         spec = {

--- a/.github/workflows/test-playbooks.yml
+++ b/.github/workflows/test-playbooks.yml
@@ -203,6 +203,25 @@ jobs:
           }
           exit 0
 
+      # Validate the runner has this playbook's prerequisites, and self-heal by
+      # installing anything missing, BEFORE running the tests. A missing model
+      # or dependency that can't be resolved fails here as a clearly-labelled
+      # provisioning issue instead of surfacing as a confusing test failure.
+      # Allow ample time: a first-time cold model pull can be slow.
+      - name: Validate & provision prerequisites (Windows)
+        if: matrix.platform == 'windows'
+        shell: powershell
+        timeout-minutes: 90
+        run: |
+          python .github/scripts/prereq_validate.py --playbook "${{ matrix.playbook }}" --platform windows --device "${{ matrix.arch }}"
+
+      - name: Validate & provision prerequisites (Linux)
+        if: matrix.platform == 'linux'
+        shell: bash
+        timeout-minutes: 90
+        run: |
+          python .github/scripts/prereq_validate.py --playbook "${{ matrix.playbook }}" --platform linux --device "${{ matrix.arch }}"
+
       - name: Extract and run tests (Windows)
         if: matrix.platform == 'windows'
         id: run_tests_windows

--- a/playbooks/core/n8n-automation-gpt-oss/README.md
+++ b/playbooks/core/n8n-automation-gpt-oss/README.md
@@ -53,18 +53,20 @@ n8n includes a **native Lemonade node** (`Lemonade Chat Model`) that provides a 
 <!-- @device:end -->
 
 <!-- @os:windows -->
-<!-- @require:lemonade,nodejs -->
+<!-- @require:lemonade,nodejs,n8n -->
 <!-- @os:end -->
 
 <!-- @os:linux -->
-<!-- @require:lemonade,podman -->
+<!-- @require:lemonade,podman,nodejs,n8n -->
 <!-- @os:end -->
 
 <!-- @device:halo,halo_box -->
+<!-- @require:lemonade-models-gpt-oss-120b -->
 <!-- @var:id=lemonade_model value="gpt-oss-120b-mxfp-GGUF" -->
 <!-- @device:end -->
 
 <!-- @device:stx,krk,rx7900xt,rx9070xt,r9700 -->
+<!-- @require:lemonade-models-gpt-oss-20b -->
 <!-- @var:id=lemonade_model value="gpt-oss-20b-mxfp4-GGUF" -->
 <!-- @device:end -->
 

--- a/playbooks/core/n8n-automation-gpt-oss/README.md
+++ b/playbooks/core/n8n-automation-gpt-oss/README.md
@@ -195,15 +195,10 @@ npm -v
 <!-- @test:end -->
 
 ## Installing n8n
+
+n8n is installed as part of the [prerequisites](#installing-software-prerequisites) above. Confirm it is available:
+
 <!-- @os:windows -->
-Install n8n globally using npm.
-
-> **Note**: You may see some npm warnings. This is expected.
-
-```bash
-npm install -g n8n
-```
-
 <!-- @test:id=n8n-version timeout=60 hidden=True -->
 ```bash
 n8n --version

--- a/playbooks/core/vscode-qwen3-coder/README.md
+++ b/playbooks/core/vscode-qwen3-coder/README.md
@@ -41,7 +41,7 @@ This tutorial demonstrates how to use Cline, VS Code, and LM Studio to run a cod
 
 ## Installing Software Prerequisites
 
-<!-- @require:lmstudio,vscode -->
+<!-- @require:lmstudio,vscode,lmstudio-models-qwen3-coder-30b -->
 
 ## Launch and Configure LM Studio
 

--- a/playbooks/dependencies/distrobox.md
+++ b/playbooks/dependencies/distrobox.md
@@ -1,0 +1,24 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Installing the Distrobox toolchain
+
+The containerized toolbox workflow needs `podman`, `distrobox`, and `pipx`:
+
+```bash
+sudo apt install -y podman distrobox pipx
+```
+
+<!-- @os:linux -->
+<!-- @test:id=distrobox-installed-linux timeout=60 hidden=True -->
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+podman --version
+distrobox version 2>/dev/null || distrobox --version
+pipx --version
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/ds4_cockpit.md
+++ b/playbooks/dependencies/ds4_cockpit.md
@@ -1,0 +1,24 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Installing ds4-cockpit
+
+[ds4-cockpit](https://github.com/kyuz0/strix-halo-ds4-toolbox) is a light terminal UI that handles creating toolbox containers, downloading model weights, and starting servers. Install it with `pipx`:
+
+```bash
+pipx install "git+https://github.com/kyuz0/strix-halo-ds4-toolbox.git#subdirectory=ds4-strix-halo-cockpit"
+```
+
+`pipx` installs the entry point into `~/.local/bin`; make sure that directory is on your `PATH`.
+
+<!-- @os:linux -->
+<!-- @test:id=ds4-cockpit-installed-linux timeout=60 hidden=True -->
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+command -v ds4-cockpit
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/ds4_toolbox_image.md
+++ b/playbooks/dependencies/ds4_toolbox_image.md
@@ -1,0 +1,25 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Pulling the ds4 toolbox container image
+
+`ds4-cockpit` runs the ds4 inference engine inside a container toolbox. In the **Interactive Toolboxes** tab, select the latest available toolbox (e.g. `ds4-rocm-7.2.4`) and click **Create/Update** to pull the image.
+
+To pull the image directly instead:
+
+```bash
+podman pull docker.io/kyuz0/strix-halo-ds4-toolbox:rocm-7.2.4
+```
+
+The toolbox version changes over time, so the check below matches the image family rather than a fixed tag.
+
+<!-- @os:linux -->
+<!-- @test:id=ds4-toolbox-image-present-linux timeout=120 hidden=True -->
+```bash
+podman images --format '{{.Repository}}:{{.Tag}}' | grep -i 'strix-halo-ds4-toolbox'
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/hermes.md
+++ b/playbooks/dependencies/hermes.md
@@ -1,0 +1,24 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Installing Hermes
+
+Install the Hermes agent CLI with the official installer. The `--skip-setup` flag keeps the install unattended:
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --skip-setup
+```
+
+Hermes installs into `~/.local/bin`; make sure that directory is on your `PATH`.
+
+<!-- @os:linux -->
+<!-- @test:id=hermes-installed-linux timeout=120 hidden=True -->
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+hermes --version
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/lemonade_models_gemma_4_e2b.md
+++ b/playbooks/dependencies/lemonade_models_gemma_4_e2b.md
@@ -1,0 +1,33 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Downloading Gemma-4 E2B for Lemonade
+
+The Lemonade server serves the Gemma-4 E2B model (`Gemma-4-E2B-it-GGUF`). To download it ahead of time:
+
+```bash
+lemonade pull Gemma-4-E2B-it-GGUF
+```
+
+`lemonade run Gemma-4-E2B-it-GGUF` also downloads the model on first use if it is not already present, then loads it for inference.
+
+The model appears in the Lemonade server's downloaded-model list once the pull completes; the checks below confirm it is present on the machine.
+
+<!-- @os:windows -->
+<!-- @test:id=lemonade-model-present-gemma-4-e2b-it-gguf-windows timeout=60 hidden=True -->
+```powershell
+curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:Gemma-4-E2B-it-GGUF
+```
+<!-- @test:end -->
+<!-- @os:end -->
+
+<!-- @os:linux -->
+<!-- @test:id=lemonade-model-present-gemma-4-e2b-it-gguf-linux timeout=60 hidden=True -->
+```bash
+curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q Gemma-4-E2B-it-GGUF
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/lemonade_models_gpt_oss_120b.md
+++ b/playbooks/dependencies/lemonade_models_gpt_oss_120b.md
@@ -1,0 +1,33 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Downloading GPT-OSS 120B for Lemonade
+
+The Lemonade server serves the GPT-OSS 120B MXFP4 GGUF model (`gpt-oss-120b-mxfp-GGUF`). To download it ahead of time:
+
+```bash
+lemonade pull gpt-oss-120b-mxfp-GGUF
+```
+
+`lemonade run gpt-oss-120b-mxfp-GGUF` also downloads the model on first use if it is not already present, then loads it for inference.
+
+The model appears in the Lemonade server's downloaded-model list once the pull completes; the checks below confirm it is present on the machine.
+
+<!-- @os:windows -->
+<!-- @test:id=lemonade-model-present-gpt-oss-windows timeout=60 hidden=True -->
+```powershell
+curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:gpt-oss-120b-mxfp-GGUF
+```
+<!-- @test:end -->
+<!-- @os:end -->
+
+<!-- @os:linux -->
+<!-- @test:id=lemonade-model-present-gpt-oss-linux timeout=60 hidden=True -->
+```bash
+curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q gpt-oss-120b-mxfp-GGUF
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/lemonade_models_gpt_oss_20b.md
+++ b/playbooks/dependencies/lemonade_models_gpt_oss_20b.md
@@ -1,0 +1,33 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Downloading GPT-OSS 20B for Lemonade
+
+The Lemonade server serves the GPT-OSS 20B MXFP4 GGUF model (`gpt-oss-20b-mxfp4-GGUF`). To download it ahead of time:
+
+```bash
+lemonade pull gpt-oss-20b-mxfp4-GGUF
+```
+
+`lemonade run gpt-oss-20b-mxfp4-GGUF` also downloads the model on first use if it is not already present, then loads it for inference.
+
+The model appears in the Lemonade server's downloaded-model list once the pull completes; the checks below confirm it is present on the machine.
+
+<!-- @os:windows -->
+<!-- @test:id=lemonade-model-present-gpt-oss-20b-windows timeout=60 hidden=True -->
+```powershell
+curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:gpt-oss-20b-mxfp4-GGUF
+```
+<!-- @test:end -->
+<!-- @os:end -->
+
+<!-- @os:linux -->
+<!-- @test:id=lemonade-model-present-gpt-oss-20b-linux timeout=60 hidden=True -->
+```bash
+curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q gpt-oss-20b-mxfp4-GGUF
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/lemonade_models_qwen3_35b_a3b.md
+++ b/playbooks/dependencies/lemonade_models_qwen3_35b_a3b.md
@@ -1,0 +1,33 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Downloading Qwen3.6 35B A3B for Lemonade
+
+The Lemonade server serves the Qwen3.6 35B A3B model (`Qwen3.6-35B-A3B-GGUF`). To download it ahead of time:
+
+```bash
+lemonade pull Qwen3.6-35B-A3B-GGUF
+```
+
+`lemonade run Qwen3.6-35B-A3B-GGUF` also downloads the model on first use if it is not already present, then loads it for inference.
+
+The model appears in the Lemonade server's downloaded-model list once the pull completes; the checks below confirm it is present on the machine.
+
+<!-- @os:windows -->
+<!-- @test:id=lemonade-model-present-qwen3-6-35b-a3b-gguf-windows timeout=60 hidden=True -->
+```powershell
+curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:Qwen3.6-35B-A3B-GGUF
+```
+<!-- @test:end -->
+<!-- @os:end -->
+
+<!-- @os:linux -->
+<!-- @test:id=lemonade-model-present-qwen3-6-35b-a3b-gguf-linux timeout=60 hidden=True -->
+```bash
+curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q Qwen3.6-35B-A3B-GGUF
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/lemonade_models_qwen3_4b.md
+++ b/playbooks/dependencies/lemonade_models_qwen3_4b.md
@@ -1,0 +1,33 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Downloading Qwen3.5 4B for Lemonade
+
+The Lemonade server serves the Qwen3.5 4B model (`Qwen3.5-4B-GGUF`). To download it ahead of time:
+
+```bash
+lemonade pull Qwen3.5-4B-GGUF
+```
+
+`lemonade run Qwen3.5-4B-GGUF` also downloads the model on first use if it is not already present, then loads it for inference.
+
+The model appears in the Lemonade server's downloaded-model list once the pull completes; the checks below confirm it is present on the machine.
+
+<!-- @os:windows -->
+<!-- @test:id=lemonade-model-present-qwen3-5-4b-gguf-windows timeout=60 hidden=True -->
+```powershell
+curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:Qwen3.5-4B-GGUF
+```
+<!-- @test:end -->
+<!-- @os:end -->
+
+<!-- @os:linux -->
+<!-- @test:id=lemonade-model-present-qwen3-5-4b-gguf-linux timeout=60 hidden=True -->
+```bash
+curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q Qwen3.5-4B-GGUF
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/lemonade_models_qwen3_coder_30b.md
+++ b/playbooks/dependencies/lemonade_models_qwen3_coder_30b.md
@@ -1,0 +1,33 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Downloading Qwen3-Coder 30B A3B for Lemonade
+
+The Lemonade server serves the Qwen3-Coder 30B A3B model (`Qwen3-Coder-30B-A3B-Instruct-GGUF`). To download it ahead of time:
+
+```bash
+lemonade pull Qwen3-Coder-30B-A3B-Instruct-GGUF
+```
+
+`lemonade run Qwen3-Coder-30B-A3B-Instruct-GGUF` also downloads the model on first use if it is not already present, then loads it for inference.
+
+The model appears in the Lemonade server's downloaded-model list once the pull completes; the checks below confirm it is present on the machine.
+
+<!-- @os:windows -->
+<!-- @test:id=lemonade-model-present-qwen3-coder-30b-a3b-instruct-gguf-windows timeout=60 hidden=True -->
+```powershell
+curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:Qwen3-Coder-30B-A3B-Instruct-GGUF
+```
+<!-- @test:end -->
+<!-- @os:end -->
+
+<!-- @os:linux -->
+<!-- @test:id=lemonade-model-present-qwen3-coder-30b-a3b-instruct-gguf-linux timeout=60 hidden=True -->
+```bash
+curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q Qwen3-Coder-30B-A3B-Instruct-GGUF
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/lemonade_models_sdxl_turbo.md
+++ b/playbooks/dependencies/lemonade_models_sdxl_turbo.md
@@ -1,0 +1,33 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Downloading SDXL-Turbo for Lemonade
+
+The Lemonade server serves the SDXL-Turbo model (`SDXL-Turbo`). To download it ahead of time:
+
+```bash
+lemonade pull SDXL-Turbo
+```
+
+`lemonade run SDXL-Turbo` also downloads the model on first use if it is not already present, then loads it for inference.
+
+The model appears in the Lemonade server's downloaded-model list once the pull completes; the checks below confirm it is present on the machine.
+
+<!-- @os:windows -->
+<!-- @test:id=lemonade-model-present-sdxl-turbo-windows timeout=60 hidden=True -->
+```powershell
+curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:SDXL-Turbo
+```
+<!-- @test:end -->
+<!-- @os:end -->
+
+<!-- @os:linux -->
+<!-- @test:id=lemonade-model-present-sdxl-turbo-linux timeout=60 hidden=True -->
+```bash
+curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q SDXL-Turbo
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/lmstudio_models_qwen3_coder_30b.md
+++ b/playbooks/dependencies/lmstudio_models_qwen3_coder_30b.md
@@ -1,0 +1,33 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Downloading Qwen3-Coder 30B on LM Studio
+
+To download the Qwen3-Coder 30B model:
+
+1. Press "Ctrl" + "Shift" + "M" on your keyboard or click on the "Discover" tab (Magnifying Glass icon) on the left sidebar
+2. Search for `Qwen3-Coder-30B-A3B`
+3. Select a quantization (the recommended `Q4_K_M` is a good balance of size and quality) and click Download
+
+LM Studio will automatically download and place the model in the correct directory.
+
+Should you wish to download additional models, you can search for them in the Discover tab and LM Studio will handle the rest.
+
+<!-- @os:windows -->
+<!-- @test:id=lmstudio-model-present-qwen3-coder-windows timeout=60 hidden=True -->
+```powershell
+lms ls --llm | Select-String -Pattern "qwen3-coder-30b"
+```
+<!-- @test:end -->
+<!-- @os:end -->
+
+<!-- @os:linux -->
+<!-- @test:id=lmstudio-model-present-qwen3-coder-linux timeout=60 hidden=True -->
+```bash
+lms ls --llm | grep -i "qwen3-coder-30b"
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/ollama.md
+++ b/playbooks/dependencies/ollama.md
@@ -1,0 +1,23 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Installing Ollama
+
+Run the official install script:
+
+```bash
+curl -fsSL https://ollama.com/install.sh | sh
+```
+
+Verify the installation:
+
+<!-- @os:linux -->
+<!-- @test:id=ollama-installed-linux timeout=60 hidden=True -->
+```bash
+ollama --version
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/ollama_models_gpt_oss_20b.md
+++ b/playbooks/dependencies/ollama_models_gpt_oss_20b.md
@@ -1,0 +1,31 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Downloading GPT-OSS 20B for Ollama
+
+Pull the GPT-OSS 20B model into Ollama:
+
+```bash
+ollama pull gpt-oss:20b
+```
+
+The Ollama server must be running for the pull to succeed; `ollama serve` starts it if it is not already running.
+
+Confirm the model is present:
+
+```bash
+ollama list
+```
+
+You should see `gpt-oss:20b` in the output along with its size and last-modified date.
+
+<!-- @os:linux -->
+<!-- @test:id=ollama-model-present-gpt-oss-20b-linux timeout=120 hidden=True -->
+```bash
+ollama list | grep -q 'gpt-oss:20b'
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/openclaw.md
+++ b/playbooks/dependencies/openclaw.md
@@ -1,0 +1,30 @@
+<!--
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
+### Installing OpenClaw
+
+Install OpenClaw with the official installer:
+
+```bash
+curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-prompt --no-onboard
+```
+
+The `--no-prompt --no-onboard` flags skip the interactive setup wizard, which is required for unattended installs; the model backend is configured separately.
+
+> **Tip:** If you see `command not found` after installation, add npm's global bin directory to your PATH:
+> ```bash
+> export PATH="$HOME/.npm-global/bin:$PATH"
+> ```
+> To make this permanent, add the line above to your `~/.bashrc` or `~/.zshrc` file.
+
+<!-- @os:linux -->
+<!-- @test:id=openclaw-installed-linux timeout=120 hidden=True -->
+```bash
+export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"
+openclaw --version
+```
+<!-- @test:end -->
+<!-- @os:end -->

--- a/playbooks/dependencies/registry.json
+++ b/playbooks/dependencies/registry.json
@@ -53,6 +53,16 @@
         "linux": [],
         "windows": []
       },
+      "validate": {
+        "linux": {
+          "cmd": "lms --help",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "lms --help",
+          "expect_rc": 0
+        }
+      },
       "versionable": true
     },
     "vllm": {
@@ -90,6 +100,26 @@
           "halo_box"
         ]
       },
+      "validate": {
+        "linux": {
+          "cmd": "export PATH=\"$HOME/.npm-global/bin:$HOME/.local/bin:$PATH\"; n8n --version",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "n8n --version",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "npm config set prefix \"$HOME/.npm-global\" && npm install -g n8n",
+          "timeout": 1200
+        },
+        "windows": {
+          "cmd": "npm install -g n8n",
+          "timeout": 1200
+        }
+      },
       "versionable": true
     },
     "vscode": {
@@ -124,6 +154,22 @@
           "halo_box"
         ]
       },
+      "validate": {
+        "linux": {
+          "cmd": "curl -sf --max-time 2 http://127.0.0.1:13305/api/v1/health",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "curl.exe -sf --max-time 2 http://127.0.0.1:13305/api/v1/health",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "sudo add-apt-repository -y ppa:lemonade-team/stable && sudo apt update && sudo apt install -y lemonade-server",
+          "timeout": 900
+        }
+      },
       "versionable": true
     },
     "lemonade-ready": {
@@ -136,6 +182,487 @@
         "linux": [],
         "windows": []
       }
+    },
+    "lemonade-models-gpt-oss-120b": {
+      "name": "GPT-OSS 120B Model (Lemonade)",
+      "description": "OpenAI GPT-OSS 120B MXFP4 GGUF model served by Lemonade",
+      "category": "model",
+      "platforms": [
+        "windows",
+        "linux"
+      ],
+      "file": "lemonade_models_gpt_oss_120b.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": [
+          "halo_box"
+        ]
+      },
+      "validate": {
+        "linux": {
+          "cmd": "curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q gpt-oss-120b-mxfp-GGUF",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:gpt-oss-120b-mxfp-GGUF",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "lemonade pull gpt-oss-120b-mxfp-GGUF",
+          "timeout": 3600
+        },
+        "windows": {
+          "cmd": "lemonade pull gpt-oss-120b-mxfp-GGUF",
+          "timeout": 3600
+        }
+      },
+      "versionable": false
+    },
+    "lemonade-models-gpt-oss-20b": {
+      "name": "GPT-OSS 20B Model (Lemonade)",
+      "description": "OpenAI GPT-OSS 20B MXFP4 GGUF model served by Lemonade",
+      "category": "model",
+      "platforms": [
+        "windows",
+        "linux"
+      ],
+      "file": "lemonade_models_gpt_oss_20b.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": [
+          "halo_box"
+        ]
+      },
+      "validate": {
+        "linux": {
+          "cmd": "curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q gpt-oss-20b-mxfp4-GGUF",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:gpt-oss-20b-mxfp4-GGUF",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "lemonade pull gpt-oss-20b-mxfp4-GGUF",
+          "timeout": 3600
+        },
+        "windows": {
+          "cmd": "lemonade pull gpt-oss-20b-mxfp4-GGUF",
+          "timeout": 3600
+        }
+      },
+      "versionable": false
+    },
+    "lemonade-models-qwen3-35b-a3b": {
+      "name": "Qwen3.6 35B A3B Model (Lemonade)",
+      "description": "Qwen3.6-35B-A3B GGUF model served by Lemonade",
+      "category": "model",
+      "platforms": [
+        "windows",
+        "linux"
+      ],
+      "file": "lemonade_models_qwen3_35b_a3b.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": [
+          "halo_box"
+        ]
+      },
+      "validate": {
+        "linux": {
+          "cmd": "curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q Qwen3.6-35B-A3B-GGUF",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:Qwen3.6-35B-A3B-GGUF",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "lemonade pull Qwen3.6-35B-A3B-GGUF",
+          "timeout": 3600
+        },
+        "windows": {
+          "cmd": "lemonade pull Qwen3.6-35B-A3B-GGUF",
+          "timeout": 3600
+        }
+      },
+      "versionable": false
+    },
+    "lemonade-models-qwen3-coder-30b": {
+      "name": "Qwen3-Coder 30B A3B Model (Lemonade)",
+      "description": "Qwen3-Coder-30B-A3B-Instruct GGUF model served by Lemonade",
+      "category": "model",
+      "platforms": [
+        "windows",
+        "linux"
+      ],
+      "file": "lemonade_models_qwen3_coder_30b.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": [
+          "halo_box"
+        ]
+      },
+      "validate": {
+        "linux": {
+          "cmd": "curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q Qwen3-Coder-30B-A3B-Instruct-GGUF",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:Qwen3-Coder-30B-A3B-Instruct-GGUF",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "lemonade pull Qwen3-Coder-30B-A3B-Instruct-GGUF",
+          "timeout": 3600
+        },
+        "windows": {
+          "cmd": "lemonade pull Qwen3-Coder-30B-A3B-Instruct-GGUF",
+          "timeout": 3600
+        }
+      },
+      "versionable": false
+    },
+    "lemonade-models-gemma-4-e2b": {
+      "name": "Gemma-4 E2B Model (Lemonade)",
+      "description": "Gemma-4-E2B-it GGUF model served by Lemonade",
+      "category": "model",
+      "platforms": [
+        "windows",
+        "linux"
+      ],
+      "file": "lemonade_models_gemma_4_e2b.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": [
+          "halo_box"
+        ]
+      },
+      "validate": {
+        "linux": {
+          "cmd": "curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q Gemma-4-E2B-it-GGUF",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:Gemma-4-E2B-it-GGUF",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "lemonade pull Gemma-4-E2B-it-GGUF",
+          "timeout": 1800
+        },
+        "windows": {
+          "cmd": "lemonade pull Gemma-4-E2B-it-GGUF",
+          "timeout": 1800
+        }
+      },
+      "versionable": false
+    },
+    "lemonade-models-qwen3-4b": {
+      "name": "Qwen3.5 4B Model (Lemonade)",
+      "description": "Qwen3.5-4B GGUF model served by Lemonade",
+      "category": "model",
+      "platforms": [
+        "windows",
+        "linux"
+      ],
+      "file": "lemonade_models_qwen3_4b.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": [
+          "halo_box"
+        ]
+      },
+      "validate": {
+        "linux": {
+          "cmd": "curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q Qwen3.5-4B-GGUF",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:Qwen3.5-4B-GGUF",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "lemonade pull Qwen3.5-4B-GGUF",
+          "timeout": 1800
+        },
+        "windows": {
+          "cmd": "lemonade pull Qwen3.5-4B-GGUF",
+          "timeout": 1800
+        }
+      },
+      "versionable": false
+    },
+    "lemonade-models-sdxl-turbo": {
+      "name": "SDXL-Turbo Model (Lemonade)",
+      "description": "SDXL-Turbo image-generation model served by Lemonade",
+      "category": "model",
+      "platforms": [
+        "windows",
+        "linux"
+      ],
+      "file": "lemonade_models_sdxl_turbo.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": [
+          "halo_box"
+        ]
+      },
+      "validate": {
+        "linux": {
+          "cmd": "curl -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | grep -q SDXL-Turbo",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "curl.exe -sf --max-time 5 http://127.0.0.1:13305/api/v1/models | findstr /C:SDXL-Turbo",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "lemonade pull SDXL-Turbo",
+          "timeout": 1800
+        },
+        "windows": {
+          "cmd": "lemonade pull SDXL-Turbo",
+          "timeout": 1800
+        }
+      },
+      "versionable": false
+    },
+    "ollama": {
+      "name": "Ollama",
+      "description": "Local LLM runner with a simple CLI and model library",
+      "category": "app",
+      "platforms": [
+        "windows",
+        "linux"
+      ],
+      "file": "ollama.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": [
+          "halo_box"
+        ]
+      },
+      "validate": {
+        "linux": {
+          "cmd": "ollama --version",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "curl -fsSL https://ollama.com/install.sh | sh",
+          "timeout": 900
+        }
+      },
+      "versionable": true
+    },
+    "ollama-models-gpt-oss-20b": {
+      "name": "GPT-OSS 20B Model (Ollama)",
+      "description": "OpenAI GPT-OSS 20B model pulled into Ollama",
+      "category": "model",
+      "platforms": [
+        "windows",
+        "linux"
+      ],
+      "file": "ollama_models_gpt_oss_20b.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": [
+          "halo_box"
+        ]
+      },
+      "validate": {
+        "linux": {
+          "cmd": "ollama list | grep -q 'gpt-oss:20b'",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "(curl -sf --max-time 2 http://127.0.0.1:11434/api/tags >/dev/null 2>&1 || (nohup ollama serve >/tmp/ollama-serve.log 2>&1 & for i in $(seq 1 30); do curl -sf --max-time 2 http://127.0.0.1:11434/api/tags >/dev/null 2>&1 && break; sleep 1; done)); ollama pull gpt-oss:20b && ollama list | grep -q 'gpt-oss:20b'",
+          "timeout": 3600
+        }
+      },
+      "versionable": false
+    },
+    "hermes": {
+      "name": "Hermes",
+      "description": "Nous Research Hermes agent CLI",
+      "category": "app",
+      "platforms": [
+        "windows",
+        "linux"
+      ],
+      "file": "hermes.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": [
+          "halo_box"
+        ]
+      },
+      "validate": {
+        "linux": {
+          "cmd": "export PATH=\"$HOME/.local/bin:$PATH\"; hermes --version",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --skip-setup",
+          "timeout": 900
+        }
+      },
+      "versionable": true
+    },
+    "distrobox": {
+      "name": "Distrobox toolchain",
+      "description": "podman, distrobox, and pipx used to run containerized toolboxes",
+      "category": "framework",
+      "platforms": [
+        "linux"
+      ],
+      "file": "distrobox.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": []
+      },
+      "validate": {
+        "linux": {
+          "cmd": "export PATH=\"$HOME/.local/bin:$PATH\"; podman --version && (distrobox version 2>/dev/null || distrobox --version) && pipx --version",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "sudo apt-get update && sudo apt-get install -y podman distrobox pipx",
+          "timeout": 900
+        }
+      },
+      "versionable": true
+    },
+    "ds4-toolbox-image": {
+      "name": "ds4 toolbox container image",
+      "description": "Container image used by ds4-cockpit to run the ds4 inference engine",
+      "category": "model",
+      "platforms": [
+        "linux"
+      ],
+      "file": "ds4_toolbox_image.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": []
+      },
+      "validate": {
+        "linux": {
+          "cmd": "podman images --format '{{.Repository}}:{{.Tag}}' | grep -i 'strix-halo-ds4-toolbox'",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "podman pull docker.io/kyuz0/strix-halo-ds4-toolbox:rocm-7.2.4 && podman images --format '{{.Repository}}:{{.Tag}}' | grep -i 'strix-halo-ds4-toolbox'",
+          "timeout": 3600
+        }
+      },
+      "versionable": false
+    },
+    "ds4-cockpit": {
+      "name": "ds4-cockpit",
+      "description": "Terminal UI for running DeepSeek V4 Flash toolboxes on Strix Halo",
+      "category": "app",
+      "platforms": [
+        "linux"
+      ],
+      "file": "ds4_cockpit.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": []
+      },
+      "validate": {
+        "linux": {
+          "cmd": "export PATH=\"$HOME/.local/bin:$PATH\"; command -v ds4-cockpit",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "export PATH=\"$HOME/.local/bin:$PATH\"; pipx install \"git+https://github.com/kyuz0/strix-halo-ds4-toolbox.git#subdirectory=ds4-strix-halo-cockpit\" && pipx ensurepath >/dev/null 2>&1; command -v ds4-cockpit || ls \"$HOME/.local/bin/ds4-cockpit\"",
+          "timeout": 900
+        }
+      },
+      "versionable": true
+    },
+    "openclaw": {
+      "name": "OpenClaw",
+      "description": "Agentic coding assistant that connects to a local Lemonade server",
+      "category": "app",
+      "platforms": [
+        "windows",
+        "linux"
+      ],
+      "file": "openclaw.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": [
+          "halo_box"
+        ]
+      },
+      "validate": {
+        "linux": {
+          "cmd": "export PATH=\"$HOME/.npm-global/bin:$HOME/.local/bin:$PATH\"; openclaw --version",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-prompt --no-onboard",
+          "timeout": 900
+        }
+      },
+      "versionable": true
     },
     "gaia": {
       "name": "GAIA",
@@ -188,6 +715,26 @@
           "halo_box"
         ]
       },
+      "validate": {
+        "linux": {
+          "cmd": "lms ls --llm | grep -i gpt-oss-120b",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "lms ls --llm | findstr /I gpt-oss-120b",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "lms get ggml-org/gpt-oss-120b-GGUF",
+          "timeout": 3600
+        },
+        "windows": {
+          "cmd": "lms get ggml-org/gpt-oss-120b-GGUF",
+          "timeout": 3600
+        }
+      },
       "versionable": false
     },
     "lmstudio-models-qwen3-9b": {
@@ -202,6 +749,47 @@
       "preinstalled": {
         "linux": [],
         "windows": []
+      },
+      "optional": true,
+      "validate": {
+        "linux": {
+          "cmd": "lms ls --llm | grep -i qwen3.5-9b",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "lms ls --llm | findstr /I qwen3.5-9b",
+          "expect_rc": 0
+        }
+      },
+      "versionable": false
+    },
+    "lmstudio-models-qwen3-coder-30b": {
+      "name": "Qwen3-Coder 30B Model",
+      "description": "Qwen3-Coder-30B-A3B model for LM Studio",
+      "category": "model",
+      "platforms": [
+        "windows",
+        "linux"
+      ],
+      "file": "lmstudio_models_qwen3_coder_30b.md",
+      "preinstalled": {
+        "linux": [
+          "halo_box"
+        ],
+        "windows": [
+          "halo_box"
+        ]
+      },
+      "optional": true,
+      "validate": {
+        "linux": {
+          "cmd": "lms ls --llm | grep -i qwen3-coder-30b",
+          "expect_rc": 0
+        },
+        "windows": {
+          "cmd": "lms ls --llm | findstr /I qwen3-coder-30b",
+          "expect_rc": 0
+        }
       },
       "versionable": false
     },
@@ -241,6 +829,18 @@
         "windows": [
           "halo_box"
         ]
+      },
+      "validate": {
+        "linux": {
+          "cmd": "hash -r 2>/dev/null; NODEBIN=\"$(command -v node || echo none)\"; echo \"node=$NODEBIN npm=$(command -v npm || echo none)\"; node --version && npm --version && { case \"$NODEBIN\" in */linuxbrew/*) echo 'homebrew node accepted'; exit 0;; esac; node -e 'process.exit(parseInt(process.versions.node.split(\".\")[0],10) >= 24 ? 0 : 1)'; }",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "sudo apt-get remove -y --purge nodejs npm libnode-dev libnode72 node-corepack 2>/dev/null; sudo apt-get autoremove -y 2>/dev/null; curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash - && sudo apt-get install -y --allow-downgrades --allow-change-held-packages nodejs && node --version && npm --version",
+          "timeout": 900
+        }
       },
       "versionable": true
     },
@@ -290,6 +890,18 @@
           "halo_box"
         ],
         "windows": []
+      },
+      "validate": {
+        "linux": {
+          "cmd": "podman --version",
+          "expect_rc": 0
+        }
+      },
+      "install": {
+        "linux": {
+          "cmd": "sudo apt update && sudo apt install -y podman docker-compose-plugin podman-compose",
+          "timeout": 600
+        }
       },
       "versionable": true
     },

--- a/playbooks/dependencies/registry.json
+++ b/playbooks/dependencies/registry.json
@@ -750,7 +750,6 @@
         "linux": [],
         "windows": []
       },
-      "optional": true,
       "validate": {
         "linux": {
           "cmd": "lms ls --llm | grep -i qwen3.5-9b",
@@ -780,7 +779,6 @@
           "halo_box"
         ]
       },
-      "optional": true,
       "validate": {
         "linux": {
           "cmd": "lms ls --llm | grep -i qwen3-coder-30b",

--- a/playbooks/supplemental/deepseek-v4-flash-ds4/README.md
+++ b/playbooks/supplemental/deepseek-v4-flash-ds4/README.md
@@ -31,6 +31,10 @@ This tutorial shows how to use `ds4-cockpit`, a terminal UI, to set up ds4, down
 
 ## Installing Software Prerequisites
 
+<!-- @require:distrobox -->
+<!-- @require:ds4-cockpit -->
+<!-- @require:ds4-toolbox-image -->
+
 > **System requirements for this configuration (single-node IQ2_XXS at 126k context):**
 > - A Strix Halo system with **at least 128 GB of unified memory**.
 > - **BIOS dedicated VRAM (UMA frame buffer) set to the minimum**, so the shared memory pool can be as large as possible.

--- a/playbooks/supplemental/gaia-agents/README.md
+++ b/playbooks/supplemental/gaia-agents/README.md
@@ -62,6 +62,7 @@ which python3
 <!-- @device:end -->
 
 <!-- @require:lemonade -->
+<!-- @require:lemonade-models-qwen3-coder-30b -->
 <!-- @require:gaia -->
 
 ## Getting Started

--- a/playbooks/supplemental/github-slack-development-digest/README.md
+++ b/playbooks/supplemental/github-slack-development-digest/README.md
@@ -76,11 +76,11 @@ test the automation, and Lemonade to run the LLM locally.
 ## Prerequisites
 
 <!-- @os:linux -->
-<!-- @require:lemonade,nodejs -->
+<!-- @require:lemonade,nodejs,lemonade-models-qwen3-35b-a3b -->
 <!-- @os:end -->
 
 <!-- @os:windows -->
-<!-- @require:lemonade,nodejs -->
+<!-- @require:lemonade,nodejs,lemonade-models-qwen3-35b-a3b -->
 <!-- @os:end -->
 
 You need:

--- a/playbooks/supplemental/hermes-lemonade-server/README.md
+++ b/playbooks/supplemental/hermes-lemonade-server/README.md
@@ -66,6 +66,8 @@ By the end of this playbook you will be able to:
 <!-- @device:end -->
 
 <!-- @require:lemonade -->
+<!-- @require:hermes -->
+<!-- @require:lemonade-models-qwen3-35b-a3b -->
 
 <!-- @var:id=hermes_model value="Qwen3.6-35B-A3B-GGUF" -->
 

--- a/playbooks/supplemental/lemonade-getting-started/README.md
+++ b/playbooks/supplemental/lemonade-getting-started/README.md
@@ -56,6 +56,7 @@ Before you begin, make sure you have:
 <!-- @device:end -->
 
 <!-- @require:lemonade -->
+<!-- @require:lemonade-models-gemma-4-e2b -->
 
 <!-- @test:id=lemonade-version timeout=60 hidden=True -->
 ```bash

--- a/playbooks/supplemental/ollama-getting-started/README.md
+++ b/playbooks/supplemental/ollama-getting-started/README.md
@@ -38,6 +38,8 @@ This playbook walks you through installing Ollama, pulling the GPT-OSS 20B model
 ## Installing Software Prerequisites
 
 <!-- @require:driver -->
+<!-- @require:ollama -->
+<!-- @require:ollama-models-gpt-oss-20b -->
 
 ### Installing Ollama
 

--- a/playbooks/supplemental/open-webui-chat/README.md
+++ b/playbooks/supplemental/open-webui-chat/README.md
@@ -113,6 +113,9 @@ This playbook needs Lemonade running as the backend and, on Linux, a container e
 <!-- @device:end -->
 <!-- @os:end -->
 
+<!-- @require:lemonade-models-qwen3-4b -->
+<!-- @require:lemonade-models-sdxl-turbo -->
+
 <!-- @test:id=lemonade-cli-verify timeout=30 hidden=True -->
 ```bash
 lemonade --version

--- a/playbooks/supplemental/openclaw-lemonade-server/README.md
+++ b/playbooks/supplemental/openclaw-lemonade-server/README.md
@@ -56,6 +56,9 @@ By the end of this playbook you will be able to:
 <!-- @os:end -->
 
 <!-- @require:lemonade -->
+<!-- @require:nodejs -->
+<!-- @require:openclaw -->
+<!-- @require:lemonade-models-qwen3-35b-a3b -->
 
 <!-- @var:id=openclaw_model value="Qwen3.6-35B-A3B-GGUF" -->
 

--- a/playbooks/supplemental/openhands-getting-started/README.md
+++ b/playbooks/supplemental/openhands-getting-started/README.md
@@ -60,11 +60,11 @@ at that model, and run your first coding task against a real project folder.
 ## Prerequisites
 
 <!-- @os:linux -->
-<!-- @require:lemonade,nodejs -->
+<!-- @require:lemonade,nodejs,lemonade-models-qwen3-35b-a3b -->
 <!-- @os:end -->
 
 <!-- @os:windows -->
-<!-- @require:lemonade,nodejs -->
+<!-- @require:lemonade,nodejs,lemonade-models-qwen3-35b-a3b -->
 <!-- @os:end -->
 
 You need:


### PR DESCRIPTION
## What

  Adds a pre-flight prerequisite gate that runs on the runner **before** each playbook's tests. For every in-scope `@require` dependency it runs a **validate → (if missing) install → re-validate** loop:

  - **validate passes** → no-op (provisioned runner, hot path)
  - **validate fails + install fixes it** → self-healed, tests proceed
  - **validate fails + can't fix** → fails fast with a *"provisioning issue, NOT a playbook bug"* banner

  ## Why

We're seeing alot of issues when implementing new playbooks (https://github.com/amd/playbooks/pull/615) or testing existing playbooks (https://github.com/amd/playbooks/issues/838)  that relate to test system setup. The current expectation is that the test system already has the dependencies pre-installed but we fail to document this or provide a simple mechanism to ensure this is done.

This simple validation script will only install dependencies in the case where a system is missing them, better handling the current status quo where this case simply fails without indicating missing deps. It'll also help automatically setup all necessary dependencies on fresh runners for our shift to OrchestrAI.


  ## Coverage (uneven by design; extensible)

  - **validate+install:** lemonade, podman, models, nodejs, n8n
  - **validate-only:**  lmstudio (until CI safe install steps determined)
  - **unchecked no-op:** driver, pytorch, comfyui, rocm, etc. — pass through until commands are added to the registry

We can either expand on each dependency (giving it tested `validate` and `install` commands in `playbooks/dependencies/registry.json`) in this PR or in a followup.