### PR TITLE
Update Playbooks (non Reference) to ROCm 10

### DIFF
--- a/playbooks/dependencies/driver.md
+++ b/playbooks/dependencies/driver.md
@@ -26,7 +26,7 @@ Get-CimInstance Win32_VideoController | Select-Object Name, DriverVersion
 <!-- @device:rx7900xt,rx9070xt,r9700 -->
 ### AMD GPU Driver
 
-Install the AMD GPU Driver (amdgpu) using the Radeon Software for Linux (RSL) flow. For instructions for your distribution, see [Install the kernel driver](https://rocm.docs.amd.com/en/7.13.0-preview/install/rocm.html).
+Install the AMD GPU Driver (amdgpu) using the Radeon Software for Linux (RSL) flow. For instructions for your distribution, see [Install the kernel driver](https://rocm.docs.amd.com/en/latest/install/rocm.html?fam=radeon&w=graphics&os=ubuntu&ubuntu-ver=26.04&i=amdgpu-install).
 
 <!-- @device:end -->
 <!-- @os:end -->

--- a/playbooks/dependencies/pytorch.md
+++ b/playbooks/dependencies/pytorch.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: MIT
 <!-- @device:halo,halo_box -->
 <!-- @test:id=install-pytorch timeout=600 setup=activate-venv -->
 ```bash
-python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "torch[device-gfx1151]==2.12.0+rocm7.14.0" "torchvision[device-gfx1151]==0.27.0+rocm7.14.0" "torchaudio==2.11.0+rocm7.14.0"
+python -m pip install --index-url https://stable.repo.amd.com/rocm/whl-next/ "torch[device-gfx1151]==2.13.0+rocm10.0.0" "torchvision[device-gfx1151]==0.28.0+rocm10.0.0" "torchaudio==2.11.0.2+rocm10.0.0"
 ```
 <!-- @test:end -->
 <!-- @device:end -->
@@ -19,7 +19,7 @@ python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "tor
 <!-- @device:stx -->
 <!-- @test:id=install-pytorch timeout=600 setup=activate-venv -->
 ```bash
-python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "torch[device-gfx1150]==2.12.0+rocm7.14.0" "torchvision[device-gfx1150]==0.27.0+rocm7.14.0" "torchaudio==2.11.0+rocm7.14.0"
+python -m pip install --index-url https://stable.repo.amd.com/rocm/whl-next/ "torch[device-gfx1150]==2.13.0+rocm10.0.0" "torchvision[device-gfx1150]==0.28.0+rocm10.0.0" "torchaudio==2.11.0.2+rocm10.0.0"
 ```
 <!-- @test:end -->
 <!-- @device:end -->
@@ -27,7 +27,7 @@ python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "tor
 <!-- @device:krk -->
 <!-- @test:id=install-pytorch timeout=600 setup=activate-venv -->
 ```bash
-python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "torch[device-gfx1152]==2.12.0+rocm7.14.0" "torchvision[device-gfx1152]==0.27.0+rocm7.14.0" "torchaudio==2.11.0+rocm7.14.0"
+python -m pip install --index-url https://stable.repo.amd.com/rocm/whl-next/ "torch[device-gfx1152]==2.13.0+rocm10.0.0" "torchvision[device-gfx1152]==0.28.0+rocm10.0.0" "torchaudio==2.11.0.2+rocm10.0.0"
 ```
 <!-- @test:end -->
 <!-- @device:end -->
@@ -35,7 +35,7 @@ python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "tor
 <!-- @device:rx7900xt -->
 <!-- @test:id=install-pytorch timeout=600 setup=activate-venv -->
 ```bash
-python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "torch[device-gfx1100]==2.12.0+rocm7.14.0" "torchvision[device-gfx1100]==0.27.0+rocm7.14.0" "torchaudio==2.11.0+rocm7.14.0"
+python -m pip install --index-url https://stable.repo.amd.com/rocm/whl-next/ "torch[device-gfx1100]==2.13.0+rocm10.0.0" "torchvision[device-gfx1100]==0.28.0+rocm10.0.0" "torchaudio==2.11.0.2+rocm10.0.0"
 ```
 <!-- @test:end -->
 <!-- @device:end -->
@@ -43,9 +43,9 @@ python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "tor
 <!-- @device:rx9070xt,r9700 -->
 <!-- @test:id=install-pytorch timeout=600 setup=activate-venv -->
 ```bash
-python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "torch[device-gfx1201]==2.12.0+rocm7.14.0" "torchvision[device-gfx1201]==0.27.0+rocm7.14.0" "torchaudio==2.11.0+rocm7.14.0"
+python -m pip install --index-url https://stable.repo.amd.com/rocm/whl-next/ "torch[device-gfx1201]==2.13.0+rocm10.0.0" "torchvision[device-gfx1201]==0.28.0+rocm10.0.0" "torchaudio==2.11.0.2+rocm10.0.0"
 ```
 <!-- @test:end -->
 <!-- @device:end -->
 
-For other devices, please refer to [ROCm 7.14 Documentation](https://rocm.docs.amd.com/projects/ai-ecosystem/en/latest/frameworks/pytorch/install.html) for full instructions.
+For other devices, please refer to [ROCm 10.0.0 Documentation](https://rocm.docs.amd.com/projects/ai-ecosystem/en/latest/frameworks/pytorch/install.html) for full instructions.

--- a/playbooks/dependencies/rocm.md
+++ b/playbooks/dependencies/rocm.md
@@ -22,7 +22,7 @@ sudo reboot
 <!-- @device:halo_box,halo -->
 <!-- @test:id=install-rocm timeout=300 setup=activate-venv -->
 ```bash
-python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "rocm[libraries,devel,device-gfx1151]==7.14.0"
+python -m pip install --index-url https://stable.repo.amd.com/rocm/whl-next/ "rocm[libraries,device-gfx1151]==10.0.0"
 ```
 <!-- @test:end -->
 <!-- @device:end -->
@@ -30,7 +30,7 @@ python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "roc
 <!-- @device:stx -->
 <!-- @test:id=install-rocm timeout=300 setup=activate-venv -->
 ```bash
-python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "rocm[libraries,devel,device-gfx1150]==7.14.0"
+python -m pip install --index-url https://stable.repo.amd.com/rocm/whl-next/ "rocm[libraries,device-gfx1150]==10.0.0"
 ```
 <!-- @test:end -->
 <!-- @device:end -->
@@ -38,7 +38,7 @@ python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "roc
 <!-- @device:krk -->
 <!-- @test:id=install-rocm timeout=300 setup=activate-venv -->
 ```bash
-python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "rocm[libraries,devel,device-gfx1152]==7.14.0"
+python -m pip install --index-url https://stable.repo.amd.com/rocm/whl-next/ "rocm[libraries,device-gfx1152]==10.0.0"
 ```
 <!-- @test:end -->
 <!-- @device:end -->
@@ -46,7 +46,7 @@ python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "roc
 <!-- @device:rx7900xt -->
 <!-- @test:id=install-rocm timeout=300 setup=activate-venv -->
 ```bash
-python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "rocm[libraries,devel,device-gfx1100]==7.14.0"
+python -m pip install --index-url https://stable.repo.amd.com/rocm/whl-next/ "rocm[libraries,device-gfx1100]==10.0.0"
 ```
 <!-- @test:end -->
 <!-- @device:end -->
@@ -54,9 +54,9 @@ python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "roc
 <!-- @device:rx9070xt,r9700 -->
 <!-- @test:id=install-rocm timeout=300 setup=activate-venv -->
 ```bash
-python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "rocm[libraries,devel,device-gfx1201]==7.14.0"
+python -m pip install --index-url https://stable.repo.amd.com/rocm/whl-next/ "rocm[libraries,device-gfx1201]==10.0.0"
 ```
 <!-- @test:end -->
 <!-- @device:end -->
 
-For further installation help, please see the [ROCm 7.14 Documentation](https://rocm.docs.amd.com/en/latest/install/rocm.html).
+For further installation help, please see the [ROCm 10.0.0 Documentation](https://rocm.docs.amd.com/en/latest/install/rocm.html).

--- a/playbooks/dependency-versions.json
+++ b/playbooks/dependency-versions.json
@@ -4,13 +4,13 @@
   "deps": {
     "rocm": {
       "reference": { "linux": "7.13.0", "windows": "7.13.0" },
-      "apu": { "linux": "7.14.0", "windows": "7.14.0" },
-      "gpu": { "linux": "7.14.0", "windows": "7.14.0" }
+      "apu": { "linux": "10.0.0", "windows": "10.0.0" },
+      "gpu": { "linux": "10.0.0", "windows": "10.0.0" }
     },
     "pytorch": {
       "reference": { "linux": "2.11", "windows": "2.11" },
-      "apu": { "linux": "2.12", "windows": "2.12" },
-      "gpu": { "linux": "2.12", "windows": "2.12" }
+      "apu": { "linux": "2.13.0", "windows": "2.13.0" },
+      "gpu": { "linux": "2.13.0", "windows": "2.13.0" }
     },
     "driver": {
       "reference": { "linux": "Latest from Ryzen AI Developer Center", "windows": "26.5.1 (from Ryzen AI Developer Center)" },


### PR DESCRIPTION
As ROCm 10 came out on August 26, this PR updates the instructions to use ROCm 10. It will also cause the runners to download ROCm 10 and the linked Pytorch artifacts, causing CI to run and check them too. 

Will fix https://github.com/amd/playbooks/issues/769