### PR TITLE
docs(clustering-rccl): correct Ray OOM prevention explanation

### DIFF
--- a/playbooks/supplemental/clustering-rccl/README.md
+++ b/playbooks/supplemental/clustering-rccl/README.md
@@ -147,11 +147,15 @@ sudo podman run -it --name vllm_cluster --replace --pull missing --network=host 
 
 vLLM uses Ray to orchestrate the cluster and RCCL to handle GPU-to-GPU communication across nodes. One machine acts as the **head node** (Machine 1), coordinating inference. The other joins as a **worker node** (Machine 2), contributing its GPU memory and compute.
 
-> **Note**: Ray is an optional dependency for vLLM and is only available from within the preconfigured Podman container. <p> In configurations where the system RAM is low, there is a risk that Ray's memory guard will kill the Ray workers because they are allocating memory higher than the threshold allowed by Ray, and the logs will output 
-<br>```ray.exceptions.OutOfMemoryError: 1 worker(s) were killed due to the node running low on memory.```<br>
-To prevent the Ray workers from being killed, export ```RAY_memory_monitor_refresh_ms=0``` on each of the machines before starting and joining the Ray cluster.
+> **Note**: Ray is an optional dependency for vLLM and is only available from within the preconfigured Podman container. 
 
 At launch, vLLM shards the model across both nodes using tensor parallelism. Once loaded, inference proceeds as if running on a single accelerator.
+
+#### Preventing Ray OOM errors
+
+By default, Ray monitors host memory on each node and kills the largest process when usage crosses 95%. On your Ryzen™ AI Halo, the GPU and the host share one pool of memory, so loading the model can trigger a `ray.exceptions.OutOfMemoryError` and kill the worker process.
+
+To prevent this, export `RAY_memory_monitor_refresh_ms=0` on each machine before starting and joining the cluster. 
 
 ### Step 1: Start the Ray Head Node (Machine 1)
 

--- a/playbooks/supplemental/clustering-rccl/README.md
+++ b/playbooks/supplemental/clustering-rccl/README.md
@@ -153,9 +153,9 @@ At launch, vLLM shards the model across both nodes using tensor parallelism. Onc
 
 #### Preventing Ray OOM errors
 
-By default, Ray monitors host memory on each node and kills the largest process when usage crosses 95%. On your Ryzen™ AI Halo, the GPU and the host share one pool of memory, so loading the model can trigger a `ray.exceptions.OutOfMemoryError` and kill the worker process.
+By default, Ray monitors host memory on each node and kills the largest process when memory usage crosses 95%. On your Ryzen™ AI Halo, the GPU and the host share one pool of memory, so loading a model can trigger a `ray.exceptions.OutOfMemoryError` and kill the worker process.
 
-To prevent this, export `RAY_memory_monitor_refresh_ms=0` on each machine before starting and joining the cluster. 
+To prevent this, we will export `RAY_memory_monitor_refresh_ms=0` on each machine before starting and joining the cluster. 
 
 ### Step 1: Start the Ray Head Node (Machine 1)
 


### PR DESCRIPTION
Replaces the inline HTML-formatted note with a dedicated subsection.
Clarifies that the issue is specific to the Ryzen AI Halo's unified
memory pool, and improves the explanation of RAY_memory_monitor_refresh_ms=0.