### PR TITLE
ci: skip Unsloth on STX

### DIFF
--- a/.github/orchestrai-config.yml
+++ b/.github/orchestrai-config.yml
@@ -88,8 +88,9 @@ extra_tags: {}
 # 128 GB for the big Halo run — the small-device runs fit in normal RAM. Tagging
 # ram_128gb ONLY on halo/halo_box lets them run on every device (no tag elsewhere
 # → tags_for() falls back to the empty extra_tags entry) instead of being dropped
-# from the non-128 GB devices by extra_tag_devices. Unsloth follows the same
-# pattern. gaia-agents also belongs here. vscode-qwen3-coder keeps the Halo tag
+# from the non-128 GB devices by extra_tag_devices. Unsloth uses the same Halo
+# tagging, while its known-OOM STX combination is excluded explicitly below.
+# gaia-agents also belongs here. vscode-qwen3-coder keeps the Halo tag
 # here, but unlike the Lemonade playbooks it loads Qwen3-Coder-30B-A3B through
 # LM Studio with full Vulkan offload (`--gpu max`) and a 32K context; current
 # 32 GB STX systems cannot satisfy that allocation and are skipped below.
@@ -106,7 +107,6 @@ device_extra_tags:
   unsloth-llms-finetuning:
     halo:     ["ram_128gb"]
     halo_box: ["ram_128gb"]
-    stx:      []
   lmstudio-rocm-llms:
     halo:     ["ram_128gb"]
     halo_box: ["ram_128gb"]
@@ -212,6 +212,10 @@ skip_devices: []
 # (device_extra_tags) and add krk to extra_tag_devices[ram_64gb); that pins them
 # to the four large hosts instead of excluding them.
 skip_playbook_devices:
+  # Current 32 GB STX machines expose insufficient usable GPU/UMA memory for
+  # this fixed model on both Linux and Windows. Re-enable when eligible STX
+  # hardware is available.
+  unsloth-llms-finetuning:  ["stx"]
   hermes-lemonade-server:  ["stx", "krk"]
   openclaw-lemonade-server: ["stx", "krk"]
   # LM Studio's survey exposed 10.71 GiB to Vulkan on Windows STX for an


### PR DESCRIPTION
## Summary

- skip unsloth-llms-finetuning on STX through the existing per-playbook/device policy
- remove the ineffective empty STX extra-tag override
- leave STX enabled for every other playbook
- leave Unsloth enabled on its other declared devices

## Why

Current 32 GB STX systems do not expose enough usable GPU/UMA memory for this fixed workload on Linux or Windows. The previous empty device-extra-tag entry did not restrict scheduling, so these combinations continued to run and fail with resource exhaustion.

## Validation

- OrchestrAI configuration parses successfully
- matrix dry run reports the explicit Unsloth/STX skip
- Gaia remains present in Linux and Windows STX batches
- Unsloth remains present on Halo, Kraken, RX 7900 XT, RX 9070 XT, and R9700 where declared