### PR TITLE
Add kernels depedency for pytorch ROCm playbook

### DIFF
--- a/playbooks/core/pytorch-rocm-llms/README.md
+++ b/playbooks/core/pytorch-rocm-llms/README.md
@@ -124,6 +124,13 @@ pip install transformers==5.10.1 safetensors accelerate sentencepiece protobuf
 ```
 <!-- @test:end -->
 <!-- @os:end -->
+
+> **Note:** If the model fails to load or runs out of memory, try installing the `kernels` package to load the model with optimized quantization.
+>
+> ```bash
+> # Use this version which is compatible with the Transformers version
+> pip install "kernels==0.14.1" 
+> ```
 <!-- @device:end -->
 
 <!-- @device:stx,krk,rx7900xt,rx9070xt,r9700 -->

--- a/playbooks/dependencies/memoryconfig.md
+++ b/playbooks/dependencies/memoryconfig.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MIT
 
 <!-- @device:halo_box -->
 
-For the Ryzen AI Halo, the dedicated GPU memory defaults to 64GB, which is sufficient for most workloads. For larger models or longer contexts, increasing this to 96GB may help. To adjust, open **AMD Software: Adrenalin Edition™** and navigate to **Performance → Tuning → AMD Variable Graphics Memory**. Reboot for the changes to take effect.
+For the Ryzen AI Halo, the dedicated GPU memory defaults to 64GB, which is sufficient for most workloads. For larger models or longer contexts, increasing this may help. To adjust, open **AMD Software: Adrenalin Edition™** and navigate to **Performance → Tuning → AMD Variable Graphics Memory**. Reboot for the changes to take effect.
 
 <p align="center">
   <img src="/api/dependencies/assets/memory-config/adrenalin_vram_new.png" alt="AMD Software Adrenalin Edition — AMD Variable Graphics Memory panel" width="600"/>
@@ -34,7 +34,7 @@ On Linux, to run larger models, increase the **shared memory** pool available to
 
 <!-- @device:halo_box -->
 
-For the AMD Ryzen™ AI Halo, the default is 96GB shared. To modify this, open the **AMD Ryzen™ AI Developer Center** and go to the **Settings** tab. Under **Graphics Performance Settings**, increase the **Shared Video Memory** slider, then click **Apply Changes** and reboot for the changes to take effect.
+For the AMD Ryzen™ AI Halo, to modify the default setting, open the **AMD Ryzen™ AI Developer Center** and go to the **Settings** tab. Under **Graphics Performance Settings**, increase the **Shared Video Memory** slider, then click **Apply Changes** and reboot for the changes to take effect.
 
 <p align="center">
   <img src="/api/dependencies/assets/memory-config/linux_mem_new.png" alt="AMD Ryzen AI Developer Center — Graphics Performance Settings with Shared Video Memory slider" width="600"/>


### PR DESCRIPTION
implements the fix here: https://github.com/amd/playbooks/issues/792

Adds a disclaimer to tell users to install the kernels package if they encounter OOM or loading errors.